### PR TITLE
Add pcssetup-to-wa10 console script

### DIFF
--- a/docs/superpowers/plans/2026-05-04-pcssetup-to-wa10.md
+++ b/docs/superpowers/plans/2026-05-04-pcssetup-to-wa10.md
@@ -1,0 +1,352 @@
+# pcssetup-to-wa10 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `pcssetup-to-wa10` console script to `toksearch_d3d` that fetches the `PCSSETUP` pointname for a given shot and writes its raw bytes to a `.wa10` file on disk.
+
+**Architecture:** New `toksearch_d3d.tools` subpackage with one module (`pcssetup_to_wa10.py`) split into a thin importable library function (`pcssetup_bytes(shot) -> bytes`) and an argparse-based `main(argv) -> int`. Wired up via `[project.scripts]` in `pyproject.toml`.
+
+**Tech Stack:** Python 3.9+, `toksearch_d3d.PtDataSignal` (which now flows through `ptdata 2.0.3`), argparse, unittest. Tests run under the existing `fdp run python testit.py` flow.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md`
+
+---
+
+## File Structure
+
+- **Create** `toksearch_d3d/tools/__init__.py` — empty marker for the new subpackage.
+- **Create** `toksearch_d3d/tools/pcssetup_to_wa10.py` — `pcssetup_bytes(shot)` + `main(argv)`.
+- **Create** `tests/test_pcssetup_to_wa10.py` — unittest cases that exercise both functions against a real shot under `fdp run`.
+- **Modify** `pyproject.toml` — add `pcssetup-to-wa10` script entry and `toksearch_d3d.tools` to the packages list.
+
+---
+
+## Task 1: Library function `pcssetup_bytes(shot)` (TDD)
+
+**Files:**
+- Create: `toksearch_d3d/tools/__init__.py`
+- Create: `toksearch_d3d/tools/pcssetup_to_wa10.py`
+- Create: `tests/test_pcssetup_to_wa10.py`
+
+- [ ] **Step 1.1: Write the failing test for `pcssetup_bytes`**
+
+Create `tests/test_pcssetup_to_wa10.py` with:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""
+Tests for the pcssetup-to-wa10 console script.
+
+Requires a configured FDP environment (run via `fdp run python testit.py`).
+Targets shot 165920, the same shot the existing PtDataSignal tests use.
+"""
+
+import unittest
+from pathlib import Path
+
+SHOT = 165920
+# PCSSETUP wa10 files are typically a few megabytes. 500 KB is well below
+# the typical payload but well above any plausible header-only / parse-
+# failure false positive.
+MIN_REASONABLE_SIZE = 500_000
+
+
+class TestPcssetupBytes(unittest.TestCase):
+    def test_returns_realistic_size(self):
+        """pcssetup_bytes returns the wa10 payload as bytes (a few MB)."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import pcssetup_bytes
+
+        b = pcssetup_bytes(SHOT)
+
+        self.assertIsInstance(b, bytes)
+        self.assertGreater(len(b), MIN_REASONABLE_SIZE)
+```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+Run:
+```bash
+cd tests && pixi run fdp run python -m unittest test_pcssetup_to_wa10 -v
+```
+
+Expected: ImportError / ModuleNotFoundError for `toksearch_d3d.tools.pcssetup_to_wa10`.
+
+- [ ] **Step 1.3: Create the empty subpackage marker**
+
+Create `toksearch_d3d/tools/__init__.py` as an empty file (no content needed; it just marks the directory as a Python package).
+
+- [ ] **Step 1.4: Implement `pcssetup_bytes`**
+
+Create `toksearch_d3d/tools/pcssetup_to_wa10.py` with:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""
+pcssetup-to-wa10: extract the PCSSETUP pointname for a shot and write
+the raw bytes to a .wa10 file -- the inverse of the PCS-side write that
+stores the wa10 file in PTDATA at shot start.
+
+Working assumption: PCSSETUP's data payload is byte-for-byte identical
+to the original wa10 file. See
+docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md.
+"""
+
+from toksearch_d3d import PtDataSignal
+
+
+def pcssetup_bytes(shot: int) -> bytes:
+    """Return the raw PCSSETUP bytes for ``shot`` as a single ``bytes`` blob.
+
+    The returned bytes are assumed to be the original wa10 file contents
+    written into PTDATA by PCS at shot start.
+    """
+    result = PtDataSignal("PCSSETUP").fetch(int(shot))
+    return result["data"].tobytes()
+```
+
+- [ ] **Step 1.5: Run the test to verify it passes**
+
+Run:
+```bash
+cd tests && pixi run fdp run python -m unittest test_pcssetup_to_wa10 -v
+```
+
+Expected: `test_returns_realistic_size ... ok` (the fetch may take a few seconds).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d
+git add toksearch_d3d/tools/__init__.py toksearch_d3d/tools/pcssetup_to_wa10.py tests/test_pcssetup_to_wa10.py
+git commit -m "feat: add pcssetup_bytes library function for wa10 extraction"
+```
+
+---
+
+## Task 2: CLI wrapper `main(argv)` (TDD)
+
+**Files:**
+- Modify: `tests/test_pcssetup_to_wa10.py`
+- Modify: `toksearch_d3d/tools/pcssetup_to_wa10.py`
+
+- [ ] **Step 2.1: Add the failing test for `main`**
+
+Append to `tests/test_pcssetup_to_wa10.py`:
+
+```python
+import io
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+
+
+class TestMain(unittest.TestCase):
+    def test_writes_file_with_default_name(self):
+        """main(["<shot>"]) writes <shot>.wa10 in cwd, returns 0."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import main, pcssetup_bytes
+
+        expected = pcssetup_bytes(SHOT)
+
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path.cwd()
+            try:
+                import os
+                os.chdir(td)
+                with redirect_stdout(io.StringIO()):
+                    rc = main([str(SHOT)])
+            finally:
+                os.chdir(cwd)
+
+            out = Path(td) / f"{SHOT}.wa10"
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            self.assertEqual(out.stat().st_size, len(expected))
+
+    def test_writes_file_with_explicit_output(self):
+        """main(["<shot>", "-o", path]) writes to that path, returns 0."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import main, pcssetup_bytes
+
+        expected = pcssetup_bytes(SHOT)
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "custom.wa10"
+            with redirect_stdout(io.StringIO()):
+                rc = main([str(SHOT), "-o", str(out)])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            self.assertEqual(out.stat().st_size, len(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2.2: Run the tests to verify they fail**
+
+Run:
+```bash
+cd tests && pixi run fdp run python -m unittest test_pcssetup_to_wa10 -v
+```
+
+Expected: the two new `TestMain.*` cases fail with `ImportError` (`main` not yet defined). The `TestPcssetupBytes.test_returns_realistic_size` from Task 1 should still pass.
+
+- [ ] **Step 2.3: Implement `main`**
+
+Append to `toksearch_d3d/tools/pcssetup_to_wa10.py`:
+
+```python
+import argparse
+import sys
+from pathlib import Path
+
+from ptdata import PtDataError
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``pcssetup-to-wa10``.
+
+    Returns the int exit code so tests can drive it without ``sys.exit``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="pcssetup-to-wa10",
+        description=(
+            "Fetch the PCSSETUP pointname for a shot and write the raw "
+            "bytes to a .wa10 file. Run under `fdp run`."
+        ),
+    )
+    parser.add_argument("shot", type=int, help="shot number")
+    parser.add_argument(
+        "-o", "--output",
+        type=Path,
+        default=None,
+        help="output path (default: <shot>.wa10 in cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    out_path = args.output or Path(f"{args.shot}.wa10")
+
+    try:
+        data = pcssetup_bytes(args.shot)
+    except PtDataError as e:
+        print(f"error: PCSSETUP fetch failed for shot {args.shot}: {e}",
+              file=sys.stderr)
+        return 1
+
+    try:
+        out_path.write_bytes(data)
+    except OSError as e:
+        print(f"error: could not write {out_path}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"wrote {len(data)} bytes to {out_path}")
+    return 0
+```
+
+- [ ] **Step 2.4: Run the tests to verify they pass**
+
+Run:
+```bash
+cd tests && pixi run fdp run python -m unittest test_pcssetup_to_wa10 -v
+```
+
+Expected: all three test cases pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d
+git add toksearch_d3d/tools/pcssetup_to_wa10.py tests/test_pcssetup_to_wa10.py
+git commit -m "feat: add pcssetup-to-wa10 CLI main()"
+```
+
+---
+
+## Task 3: Wire up the console script
+
+**Files:**
+- Modify: `pyproject.toml` (currently `pyproject.toml:31-35`)
+
+- [ ] **Step 3.1: Add the script entry and subpackage**
+
+In `pyproject.toml`, update the `[project.scripts]` block and the `[tool.setuptools]` `packages` list:
+
+```toml
+[project.scripts]
+fdp = "toksearch_d3d.fdp.cli:main"
+pcssetup-to-wa10 = "toksearch_d3d.tools.pcssetup_to_wa10:main"
+
+[tool.setuptools]
+packages = ["toksearch_d3d", "toksearch_d3d.fdp", "toksearch_d3d.signal", "toksearch_d3d.tools"]
+zip-safe = false
+```
+
+- [ ] **Step 3.2: Reinstall in editable mode and verify the entry point**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d
+pixi run pip install --no-deps --no-build-isolation -e .
+pixi run which pcssetup-to-wa10
+pixi run pcssetup-to-wa10 --help
+```
+
+Expected: `which` prints the env's bin path; `--help` prints the argparse usage with `shot` and `-o/--output`.
+
+- [ ] **Step 3.3: Smoke-test end-to-end against the test shot**
+
+Run:
+```bash
+cd /tmp && pixi --manifest-path /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d/pixi.toml run fdp run pcssetup-to-wa10 165920 -o /tmp/165920.wa10
+ls -la /tmp/165920.wa10
+```
+
+Expected: prints `wrote N bytes to /tmp/165920.wa10` where N is in the multi-megabyte range; the file exists with that size.
+
+Clean up: `rm /tmp/165920.wa10`.
+
+- [ ] **Step 3.4: Run the full toksearch_d3d test suite**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d/tests && pixi run fdp run python testit.py
+```
+
+Expected: all tests pass (existing 54 + the 3 new pcssetup tests = 57). No regressions.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch_d3d
+git add pyproject.toml
+git commit -m "build: register pcssetup-to-wa10 console script"
+```
+
+---
+
+## Self-review checklist (for the plan author)
+
+Before handing off:
+
+- [ ] **Spec coverage:**
+  - "CLI surface: `pcssetup-to-wa10 <shot> [-o <path>]`" → Task 2 (argparse) + Task 3 (entry point).
+  - "Default output `<shot>.wa10` in cwd" → Task 2.3 (`out_path = args.output or Path(f"{args.shot}.wa10")`) + Task 2.1 test.
+  - "Module layout: `toksearch_d3d/tools/{__init__.py, pcssetup_to_wa10.py}`" → Tasks 1.3, 1.4.
+  - "`pcssetup_bytes(shot) -> bytes` importable" → Task 1.4.
+  - "`main(argv=None) -> int`" → Task 2.3.
+  - "Catches PtDataError and OSError, prints one-line stderr, exit 1" → Task 2.3.
+  - "Prints `wrote N bytes to <path>` on success" → Task 2.3.
+  - "Tests under fdp run, shot 165920, size > 500 KB" → Task 1.1 + Task 2.1.
+  - "`pyproject.toml` script entry + packages list" → Task 3.1.
+  - "No CHANGELOG section" → not in plan; correct.
+
+- [ ] **No placeholders.** All code blocks contain runnable code; all commands have explicit expected output.
+
+- [ ] **Type consistency.** Function name `pcssetup_bytes` matches across all tasks. CLI arg `--output` and attribute `args.output` consistent. Exit codes (`0`, `1`) used consistently.

--- a/docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md
+++ b/docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md
@@ -1,0 +1,108 @@
+# pcssetup-to-wa10 — design
+
+Date: 2026-05-04
+Status: Draft
+
+## Goal
+
+Add a console script to `toksearch_d3d` that fetches the `PCSSETUP`
+pointname for a given shot and writes its raw bytes to a `.wa10`
+file on disk — the inverse of the PCS-side process that writes a
+`wa10` binary into PTDATA at shot start.
+
+## Background
+
+When a DIII-D shot starts, PCS records its setup as a binary `wa10`
+file and writes that file's contents into PTDATA under the
+`PCSSETUP` pointname. PCS users occasionally need to recover the
+original `wa10` for an old shot — currently there is no toksearch_d3d
+tool that does this.
+
+PCSSETUP `wa10` files are typically a few megabytes.
+
+## Working assumption
+
+The `data` payload returned by `PtDataSignal('PCSSETUP').fetch(shot)`
+is byte-for-byte identical to the original `wa10` file contents. We
+estimate ~90% confidence in this and have no canonical reference
+`wa10` to diff against today; the script is built on this assumption
+and a `--verify` flag can be added later when a reference becomes
+available.
+
+## CLI surface
+
+A new top-level console script registered in `pyproject.toml`:
+
+```
+pcssetup-to-wa10 <shot> [-o <output_path>]
+```
+
+- `<shot>`: required, integer shot number.
+- `-o/--output`: optional output path. Default: `<shot>.wa10` in cwd.
+
+Single shot per invocation; batch is left to the shell. Exit 0 on
+success; exit 1 with a one-line stderr message if the fetch fails
+(e.g. `error: PCSSETUP not found for shot 165920`).
+
+The script must be invoked under a configured FDP environment
+(typically `fdp run pcssetup-to-wa10 ...`), the same as the rest of
+toksearch_d3d's data-access tooling.
+
+## Module layout
+
+- `toksearch_d3d/tools/__init__.py` — new, empty.
+- `toksearch_d3d/tools/pcssetup_to_wa10.py` — new module.
+  - `pcssetup_bytes(shot: int) -> bytes` — importable library
+    function. Calls
+    `toksearch_d3d.PtDataSignal('PCSSETUP').fetch(shot)` and
+    returns `result['data'].tobytes()`.
+  - `main(argv: list[str] | None = None) -> int` — argparse-based
+    CLI entry point. Wraps `pcssetup_bytes`, handles I/O, prints
+    `wrote N bytes to <path>` on success, returns the int exit
+    code. Catches `PtDataError` (and `OSError` on write) to emit a
+    one-line stderr message instead of a traceback.
+
+`pyproject.toml` changes:
+
+- `[project.scripts]` adds:
+  ```
+  pcssetup-to-wa10 = "toksearch_d3d.tools.pcssetup_to_wa10:main"
+  ```
+- `[tool.setuptools] packages` list adds `toksearch_d3d.tools`.
+
+## Tests
+
+`tests/test_pcssetup_to_wa10.py`, runnable under the existing
+`fdp run python testit.py` flow:
+
+- `test_pcssetup_bytes_returns_realistic_size`: assert
+  `pcssetup_bytes(SHOT)` returns `bytes` with `len(b) > 500_000`.
+  500 KB is well below the typical "few MB" payload but well above
+  any plausible header-only / parse-failure false positive.
+- `test_main_writes_file`: invoke `main([str(SHOT), "-o",
+  str(tmp_path)])`, assert exit code 0 and that the file exists
+  with size equal to `len(pcssetup_bytes(SHOT))`.
+
+Pick a shot that is known-old enough to have stable PCSSETUP data
+across the test horizon (the existing PtDataSignal tests use shot
+`165920`, which works here too).
+
+No fixtures committed to the repo; data is fetched from FDP at
+runtime, same as the existing `test_ptdata_signal.py` suite.
+
+## Out of scope
+
+- `--verify <ref.wa10>` — easy to add later when a reference `wa10`
+  is available; defer to keep the initial surface minimal.
+- Multi-shot batch mode — shell loops are sufficient.
+- Round-trip verification (write a `wa10`, push it back into PTDATA,
+  read it back, compare) — purely a read-side tool.
+
+## Open risks
+
+- **Working assumption may be wrong.** If the PCSSETUP payload has
+  any header/transform around the wa10 bytes, the produced file
+  will not be byte-identical to the original. Mitigation: the
+  `--verify` flag (deferred) is one line of comparison; users with
+  a reference can validate immediately. Until then, a >500 KB size
+  check at least catches the empty/header-only failure mode.

--- a/pixi.lock
+++ b/pixi.lock
@@ -5336,12 +5336,12 @@ packages:
   timestamp: 1777933206156
 - pypi: ./
   name: toksearch-d3d
-  version: 0.4.0+1.gab15f96.dirty
-  sha256: aea5dd30495c6e791c3560c46c08e97fe24322ee8296da22956059a3beef0ba0
+  version: 0.5.0+8.g96a8966.dirty
+  sha256: b8468bc89b95b5aa8a966d6ef258345bab6c1504e47b47b532050329d1c8dda7
   requires_dist:
   - imas-composer ; extra == 'imas'
   - awkward>=2.0 ; extra == 'imas'
-  requires_python: '>=3.9'
+  requires_python: '>=3.11'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ imas = ["imas_composer", "awkward>=2.0"]
 
 [project.scripts]
 fdp = "toksearch_d3d.fdp.cli:main"
+pcssetup-to-wa10 = "toksearch_d3d.tools.pcssetup_to_wa10:main"
 
 [tool.setuptools]
-packages = ["toksearch_d3d", "toksearch_d3d.fdp", "toksearch_d3d.signal"]
+packages = ["toksearch_d3d", "toksearch_d3d.fdp", "toksearch_d3d.signal", "toksearch_d3d.tools"]
 zip-safe = false
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 description = "TokSearch DIII-D: Signal retrieval classes for DIII-D fusion experiment data"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = []
 
 [project.optional-dependencies]

--- a/tests/test_pcssetup_to_wa10.py
+++ b/tests/test_pcssetup_to_wa10.py
@@ -1,0 +1,31 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""
+Tests for the pcssetup-to-wa10 console script.
+
+Requires a configured FDP environment (run via `fdp run python testit.py`).
+Targets shot 165920, the same shot the existing PtDataSignal tests use.
+"""
+
+import unittest
+from pathlib import Path
+
+SHOT = 165920
+# PCSSETUP wa10 files are typically a few megabytes. 500 KB is well below
+# the typical payload but well above any plausible header-only / parse-
+# failure false positive.
+MIN_REASONABLE_SIZE = 500_000
+
+
+class TestPcssetupBytes(unittest.TestCase):
+    def test_returns_realistic_size(self):
+        """pcssetup_bytes returns the wa10 payload as bytes (a few MB)."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import pcssetup_bytes
+
+        b = pcssetup_bytes(SHOT)
+
+        self.assertIsInstance(b, bytes)
+        self.assertGreater(len(b), MIN_REASONABLE_SIZE)

--- a/tests/test_pcssetup_to_wa10.py
+++ b/tests/test_pcssetup_to_wa10.py
@@ -18,21 +18,23 @@ from contextlib import redirect_stdout
 from pathlib import Path
 
 SHOT = 165920
-# PCSSETUP wa10 files are typically a few megabytes. 500 KB is well below
-# the typical payload but well above any plausible header-only / parse-
-# failure false positive.
-MIN_REASONABLE_SIZE = 500_000
+# Shot 165920's PCSSETUP payload: 320565 int32 words = 1,282,260 bytes.
+# Hardcoding this exact value is the regression guard: if pcssetup_bytes
+# accidentally goes back to ical=1 (Full calibration), the result becomes
+# float64 (8 bytes/sample) and doubles in size, failing this assertion.
+EXPECTED_SIZE_165920 = 320_565 * 4
 
 
 class TestPcssetupBytes(unittest.TestCase):
-    def test_returns_realistic_size(self):
-        """pcssetup_bytes returns the wa10 payload as bytes (a few MB)."""
+    def test_returns_raw_int32_payload(self):
+        """pcssetup_bytes returns the raw int32 wa10 payload (not calibrated float64)."""
         from toksearch_d3d.tools.pcssetup_to_wa10 import pcssetup_bytes
 
         b = pcssetup_bytes(SHOT)
 
         self.assertIsInstance(b, bytes)
-        self.assertGreater(len(b), MIN_REASONABLE_SIZE)
+        # Exact size catches calibration-mode regression (would be 2x at ical=1).
+        self.assertEqual(len(b), EXPECTED_SIZE_165920)
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_pcssetup_to_wa10.py
+++ b/tests/test_pcssetup_to_wa10.py
@@ -29,3 +29,50 @@ class TestPcssetupBytes(unittest.TestCase):
 
         self.assertIsInstance(b, bytes)
         self.assertGreater(len(b), MIN_REASONABLE_SIZE)
+
+
+import io
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+
+
+class TestMain(unittest.TestCase):
+    def test_writes_file_with_default_name(self):
+        """main(["<shot>"]) writes <shot>.wa10 in cwd, returns 0."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import main, pcssetup_bytes
+
+        expected = pcssetup_bytes(SHOT)
+
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path.cwd()
+            try:
+                import os
+                os.chdir(td)
+                with redirect_stdout(io.StringIO()):
+                    rc = main([str(SHOT)])
+            finally:
+                os.chdir(cwd)
+
+            out = Path(td) / f"{SHOT}.wa10"
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            self.assertEqual(out.stat().st_size, len(expected))
+
+    def test_writes_file_with_explicit_output(self):
+        """main(["<shot>", "-o", path]) writes to that path, returns 0."""
+        from toksearch_d3d.tools.pcssetup_to_wa10 import main, pcssetup_bytes
+
+        expected = pcssetup_bytes(SHOT)
+
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "custom.wa10"
+            with redirect_stdout(io.StringIO()):
+                rc = main([str(SHOT), "-o", str(out)])
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(out.is_file())
+            self.assertEqual(out.stat().st_size, len(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pcssetup_to_wa10.py
+++ b/tests/test_pcssetup_to_wa10.py
@@ -10,7 +10,11 @@ Requires a configured FDP environment (run via `fdp run python testit.py`).
 Targets shot 165920, the same shot the existing PtDataSignal tests use.
 """
 
+import contextlib
+import io
+import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 SHOT = 165920
@@ -31,11 +35,6 @@ class TestPcssetupBytes(unittest.TestCase):
         self.assertGreater(len(b), MIN_REASONABLE_SIZE)
 
 
-import io
-import tempfile
-from contextlib import redirect_stderr, redirect_stdout
-
-
 class TestMain(unittest.TestCase):
     def test_writes_file_with_default_name(self):
         """main(["<shot>"]) writes <shot>.wa10 in cwd, returns 0."""
@@ -44,14 +43,8 @@ class TestMain(unittest.TestCase):
         expected = pcssetup_bytes(SHOT)
 
         with tempfile.TemporaryDirectory() as td:
-            cwd = Path.cwd()
-            try:
-                import os
-                os.chdir(td)
-                with redirect_stdout(io.StringIO()):
-                    rc = main([str(SHOT)])
-            finally:
-                os.chdir(cwd)
+            with contextlib.chdir(td), redirect_stdout(io.StringIO()):
+                rc = main([str(SHOT)])
 
             out = Path(td) / f"{SHOT}.wa10"
             self.assertEqual(rc, 0)

--- a/toksearch_d3d/tools/pcssetup_to_wa10.py
+++ b/toksearch_d3d/tools/pcssetup_to_wa10.py
@@ -24,10 +24,16 @@ from toksearch_d3d import PtDataSignal
 def pcssetup_bytes(shot: int) -> bytes:
     """Return the raw PCSSETUP bytes for ``shot`` as a single ``bytes`` blob.
 
-    The returned bytes are assumed to be the original wa10 file contents
-    written into PTDATA by PCS at shot start.
+    Fetches in raw mode (``ical=0``) with no time or units fetches, so the
+    returned bytes are the integer payload PTDATA stores -- the same byte
+    stream PCS wrote into PTDATA from the original wa10 file at shot start.
+    With default ``ical=1`` (Full calibration) the engine would return
+    float64 calibrated values (8 bytes/sample, sign-flipped) which is not
+    the wa10 file.
     """
-    result = PtDataSignal("PCSSETUP").fetch(int(shot))
+    result = PtDataSignal(
+        "PCSSETUP", ical=0, fetch_times=False, fetch_units=False
+    ).fetch(int(shot))
     return result["data"].tobytes()
 
 

--- a/toksearch_d3d/tools/pcssetup_to_wa10.py
+++ b/toksearch_d3d/tools/pcssetup_to_wa10.py
@@ -1,0 +1,26 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""
+pcssetup-to-wa10: extract the PCSSETUP pointname for a shot and write
+the raw bytes to a .wa10 file -- the inverse of the PCS-side write that
+stores the wa10 file in PTDATA at shot start.
+
+Working assumption: PCSSETUP's data payload is byte-for-byte identical
+to the original wa10 file. See
+docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md.
+"""
+
+from toksearch_d3d import PtDataSignal
+
+
+def pcssetup_bytes(shot: int) -> bytes:
+    """Return the raw PCSSETUP bytes for ``shot`` as a single ``bytes`` blob.
+
+    The returned bytes are assumed to be the original wa10 file contents
+    written into PTDATA by PCS at shot start.
+    """
+    result = PtDataSignal("PCSSETUP").fetch(int(shot))
+    return result["data"].tobytes()

--- a/toksearch_d3d/tools/pcssetup_to_wa10.py
+++ b/toksearch_d3d/tools/pcssetup_to_wa10.py
@@ -24,3 +24,50 @@ def pcssetup_bytes(shot: int) -> bytes:
     """
     result = PtDataSignal("PCSSETUP").fetch(int(shot))
     return result["data"].tobytes()
+
+
+import argparse
+import sys
+from pathlib import Path
+
+from ptdata import PtDataError
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``pcssetup-to-wa10``.
+
+    Returns the int exit code so tests can drive it without ``sys.exit``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="pcssetup-to-wa10",
+        description=(
+            "Fetch the PCSSETUP pointname for a shot and write the raw "
+            "bytes to a .wa10 file. Run under `fdp run`."
+        ),
+    )
+    parser.add_argument("shot", type=int, help="shot number")
+    parser.add_argument(
+        "-o", "--output",
+        type=Path,
+        default=None,
+        help="output path (default: <shot>.wa10 in cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    out_path = args.output or Path(f"{args.shot}.wa10")
+
+    try:
+        data = pcssetup_bytes(args.shot)
+    except PtDataError as e:
+        print(f"error: PCSSETUP fetch failed for shot {args.shot}: {e}",
+              file=sys.stderr)
+        return 1
+
+    try:
+        out_path.write_bytes(data)
+    except OSError as e:
+        print(f"error: could not write {out_path}: {e}", file=sys.stderr)
+        return 1
+
+    print(f"wrote {len(data)} bytes to {out_path}")
+    return 0

--- a/toksearch_d3d/tools/pcssetup_to_wa10.py
+++ b/toksearch_d3d/tools/pcssetup_to_wa10.py
@@ -13,6 +13,11 @@ to the original wa10 file. See
 docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md.
 """
 
+import argparse
+import sys
+from pathlib import Path
+
+from ptdata import PtDataError
 from toksearch_d3d import PtDataSignal
 
 
@@ -24,13 +29,6 @@ def pcssetup_bytes(shot: int) -> bytes:
     """
     result = PtDataSignal("PCSSETUP").fetch(int(shot))
     return result["data"].tobytes()
-
-
-import argparse
-import sys
-from pathlib import Path
-
-from ptdata import PtDataError
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

Adds a new `pcssetup-to-wa10` console script that fetches the `PCSSETUP` pointname for a DIII-D shot via `toksearch_d3d.PtDataSignal` and writes the raw integer payload to a `.wa10` file on disk — the inverse of the PCS-side write that stores the wa10 file in PTDATA at shot start.

```
pcssetup-to-wa10 <shot> [-o <output_path>]
```

Default output is `<shot>.wa10` in cwd. Run under `fdp run`.

## What's new

- `toksearch_d3d/tools/pcssetup_to_wa10.py`
  - `pcssetup_bytes(shot: int) -> bytes` — importable library function. Fetches in raw mode (`ical=0, fetch_times=False, fetch_units=False`) so the returned bytes are the int32 payload PTDATA stores, not float64 calibrated values.
  - `main(argv) -> int` — argparse CLI with one-line stderr error reporting on `PtDataError`/`OSError`.
- `pyproject.toml` — registers the console script and adds `toksearch_d3d.tools` to the packages list. Bumps `requires-python` to `>=3.11` to match in-repo usage of PEP 604 union syntax and `contextlib.chdir`.
- `tests/test_pcssetup_to_wa10.py` — three unittest cases (live FDP backend, shot 165920) covering library function, default-output CLI, and explicit-output CLI. The size assertion is exact (`320565 * 4 = 1_282_260` bytes for shot 165920) so a calibration-mode regression would surface immediately.
- `docs/superpowers/specs/2026-05-04-pcssetup-to-wa10-design.md`, `docs/superpowers/plans/2026-05-04-pcssetup-to-wa10.md` — design and implementation plan.

## Working assumption

The PCSSETUP raw int32 byte stream equals the original wa10 file written by PCS. We have no canonical reference wa10 to diff against today — a `--verify <ref.wa10>` flag is deferred until a reference becomes available. The exact-size test would catch a silent calibration regression even without a byte-equality reference.

## Test plan

- [x] `cd tests && pixi run fdp run python -m unittest test_pcssetup_to_wa10 -v` — 3/3 passing
- [x] Full suite `cd tests && pixi run fdp run python testit.py` — 57/57 passing (54 existing + 3 new)
- [x] Smoke: `pcssetup-to-wa10 165920 -o /tmp/165920.wa10` writes 1,282,260 bytes
- [ ] CI green
- [ ] Eventually: byte-diff against a real wa10 reference (separate PR adding `--verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)