### PR TITLE
Stop clobbering pre-set env vars in fdp CLI

### DIFF
--- a/tests/test_fdp_cli.py
+++ b/tests/test_fdp_cli.py
@@ -1,0 +1,57 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for toksearch_d3d.fdp.cli.apply_environment."""
+
+import unittest
+
+from toksearch_d3d.fdp.cli import DEFAULT_CONFIG, apply_environment
+
+
+class TestApplyEnvironment(unittest.TestCase):
+    def test_path_always_overwritten(self):
+        """PATH is overwritten because config["PATH"] already incorporates the existing PATH."""
+        env = {"PATH": "/existing/bin"}
+        config = {"PATH": "/new/bin:/existing/bin"}
+        apply_environment(config, env)
+        self.assertEqual(env["PATH"], "/new/bin:/existing/bin")
+
+    def test_existing_value_not_clobbered(self):
+        """User-set values for non-PATH keys are preserved."""
+        env = {"PATH": "/p", "TDSVER": "8.0"}
+        config = {"PATH": "/p", "TDSVER": "7.0"}
+        apply_environment(config, env)
+        self.assertEqual(env["TDSVER"], "8.0")
+
+    def test_missing_value_filled_from_config(self):
+        """Keys not present in env get the default from config."""
+        env = {"PATH": "/p"}
+        config = {"PATH": "/p", "MKL_NUM_THREADS": "1"}
+        apply_environment(config, env)
+        self.assertEqual(env["MKL_NUM_THREADS"], "1")
+
+    def test_mutates_in_place(self):
+        """env is mutated in place (no rebind), preserving os._Environ semantics."""
+        env = {"PATH": "/p"}
+        original_id = id(env)
+        result = apply_environment({"PATH": "/p", "FOO": "bar"}, env)
+        self.assertIsNone(result)
+        self.assertEqual(id(env), original_id)
+        self.assertEqual(env["FOO"], "bar")
+
+    def test_real_default_config_against_synthetic_env(self):
+        """End-to-end with the real DEFAULT_CONFIG: PATH applied, existing kept, missing filled."""
+        env = {"PATH": "/system/bin", "OMP_NUM_THREADS": "4"}
+        apply_environment(DEFAULT_CONFIG, env)
+        # PATH always replaced with config's value (which prepends the env's bin_dir).
+        self.assertEqual(env["PATH"], DEFAULT_CONFIG["PATH"])
+        # User-set OMP_NUM_THREADS survives.
+        self.assertEqual(env["OMP_NUM_THREADS"], "4")
+        # TDSVER wasn't in env, gets the default.
+        self.assertEqual(env["TDSVER"], "7.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toksearch_d3d/fdp/cli.py
+++ b/toksearch_d3d/fdp/cli.py
@@ -226,6 +226,20 @@ BACKENDS = {
 }
 
 
+def apply_environment(config, env):
+    """Apply config to env, preserving existing values except PATH.
+
+    PATH is overwritten unconditionally because DEFAULT_CONFIG["PATH"]
+    is built by prepending the env's bin_dir to the existing PATH at
+    import time, so we must always write it through.
+    """
+    env["PATH"] = config["PATH"]
+    for k, v in config.items():
+        if k == "PATH":
+            continue
+        env.setdefault(k, v)
+
+
 ##############################################################################
 #
 # CLI SUB COMMMANDS
@@ -384,7 +398,7 @@ def main():
     args = parser.parse_args()
 
     ################# Environment setup ####################
-    os.environ |= DEFAULT_CONFIG
+    apply_environment(DEFAULT_CONFIG, os.environ)
 
     bearer_token = args.bearer_token or os.getenv("BEARER_TOKEN", "")
     if not bearer_token:


### PR DESCRIPTION
## Summary

- `os.environ |= DEFAULT_CONFIG` in `fdp/cli.py` was letting defaults win over whatever the user already had set. Replace with an `apply_environment(config, env)` helper that uses `setdefault` for every key except `PATH`.
- `PATH` is still written unconditionally because `DEFAULT_CONFIG["PATH"]` is built at import time as `f"{bin_dir}:{os.getenv('PATH', '')}"` — the whole point of the entry is to prepend the active env's `bin_dir`.
- The helper mutates `os.environ` in place, preserving its `os._Environ` type so subsequent assignments (e.g. `BEARER_TOKEN`) still propagate to libc and C-extension consumers (XRootD, MDSplus, pymssql/FreeTDS).

## Test plan

- [x] `pixi run python -m unittest tests.test_fdp_cli -v` — 5 new tests pass (PATH always overwritten, existing values preserved, missing values filled, in-place mutation, end-to-end against real `DEFAULT_CONFIG`).
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)