### PR TITLE
Exclude internal planning docs from mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,9 @@ repo_name: GA-FDP/toksearch_d3d
 repo_url: https://github.com/GA-FDP/toksearch_d3d
 edit_uri: ""
 
+# Internal planning docs -- not user-facing.
+exclude_docs: |
+  superpowers/
 
 plugins:
   - mkdocstrings:


### PR DESCRIPTION
## Summary

Adds `exclude_docs: superpowers/` to `mkdocs.yml`. The `docs/superpowers/plans/*.md` and `docs/superpowers/specs/*.md` files are internal planning documents used by the brainstorming/writing-plans workflow; they're not user-facing and shouldn't be in the published site.

Concretely, `mkdocs serve` was crashing on `docs/superpowers/plans/2026-05-04-pcssetup-to-wa10.md` with:

```
ERROR - Error reading page 'superpowers/plans/2026-05-04-pcssetup-to-wa10.md':
        'NoneType' object has no attribute 'replace'
```

Traceback bottoms out in `pymdownx.highlight` → pygments `HtmlFormatter.__init__` getting `filename=None` instead of `''` from `options.get('filename', '')`. Rather than chasing the specific markdown construct that triggers the pygments bug, just exclude the whole `superpowers/` subtree.

## Test plan

- [ ] `pixi run -e docs mkdocs build` exits clean (was crashing before)
- [ ] Published site has no `superpowers/` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)