### PR TITLE
Correct AmSC description in AMSC_PRESET docstring

### DIFF
--- a/toksearch_d3d/llm/__init__.py
+++ b/toksearch_d3d/llm/__init__.py
@@ -18,8 +18,10 @@ Exposes:
 - ``skills_path``: directory of DIII-D-specific SKILL.md files, registered
   via the ``toksearch.llm.skills`` entry point.
 - ``AMSC_PRESET``: a backend preset that points the Anthropic backend at
-  GA's American Science Cloud endpoint with ``~/amsc_api_key`` as the key
-  source, registered via the ``toksearch.llm.presets`` entry point.
+  the American Science Cloud (AmSC) Anthropic-compatible endpoint, with
+  ``~/amsc_api_key`` as the key source, registered via the
+  ``toksearch.llm.presets`` entry point. AmSC is generally available to
+  AmSC users; it is not GA-operated.
 
 The ``toksearch.llm.namespace`` entry point points at ``toksearch_d3d``
 itself (whose ``__init__.py`` defines ``__llm_description__``).

--- a/toksearch_d3d/llm/__init__.py
+++ b/toksearch_d3d/llm/__init__.py
@@ -21,7 +21,7 @@ Exposes:
   the American Science Cloud (AmSC) Anthropic-compatible endpoint, with
   ``~/amsc_api_key`` as the key source, registered via the
   ``toksearch.llm.presets`` entry point. AmSC is generally available to
-  AmSC users; it is not GA-operated.
+  AmSC users.
 
 The ``toksearch.llm.namespace`` entry point points at ``toksearch_d3d``
 itself (whose ``__init__.py`` defines ``__llm_description__``).


### PR DESCRIPTION
## Summary

Small docstring correction: the AmSC endpoint at \`api.i2-core.american-science-cloud.org\` is generally available to AmSC users, not a GA-operated resource. Updates \`toksearch_d3d/llm/__init__.py\`'s \`AMSC_PRESET\` docstring to say so. No behavior change.

Paired with a similar fix in toksearch (PR #33's branch) updating the LLM reference doc, tutorial, and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)