### PR TITLE
Fix env API consumer + add D3dImasSignal + decouple LLM preset

### DIFF
--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -89,7 +89,9 @@ ImasSignal (Experimental)
 =========================
 
 Fetches DIII-D data via the IMAS IDS schema using ``imas_composer``.
-Only available when ``imas_composer`` is installed.
+Only available when ``imas_composer`` is installed. Also exported as
+``D3dImasSignal`` (an exact alias) for device-prefixed symmetry with other
+device packages, e.g. ``toksearch_mast.MastImasSignal``.
 
 **Leaf path** — fetches one field::
 
@@ -222,7 +224,7 @@ from .signal.ptdata import RDataSignal
 from .signal.cake import CakeSignal
 
 try:
-    from .signal.imas import ImasSignal, list_imas_fields
+    from .signal.imas import ImasSignal, D3dImasSignal, list_imas_fields
 except ImportError:
     pass
 

--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -209,14 +209,13 @@ _os.environ.setdefault(
     "XRD_PLUGINCONFDIR",
     _os.path.join(_conda_prefix, "etc", "xrootd", "client.plugins.d"),
 )
-from fdp.environment import _generic_config as _fdp_generic_config
+from fdp.environment import build_device_config as _fdp_build_device_config
+from fdp.environment import _resolve_device_handle as _fdp_resolve_device_handle
 from fdp.environment import apply_environment as _fdp_apply_environment
-from fdp.environment import _resolve_device_env as _fdp_resolve_device_env
-_fdp_cfg = _fdp_generic_config()
-_fdp_cfg.update(_fdp_resolve_device_env("d3d"))
+_fdp_cfg = _fdp_build_device_config(_fdp_resolve_device_handle("d3d"))
 _fdp_apply_environment(_fdp_cfg, _os.environ)
 del _os, _sys, _conda_prefix
-del _fdp_generic_config, _fdp_apply_environment, _fdp_resolve_device_env, _fdp_cfg
+del _fdp_build_device_config, _fdp_resolve_device_handle, _fdp_apply_environment, _fdp_cfg
 
 from .signal.ptdata import PtDataSignal
 from .signal.ptdata import RDataSignal

--- a/toksearch_d3d/data/d3d.yaml
+++ b/toksearch_d3d/data/d3d.yaml
@@ -3,7 +3,11 @@ name: d3d
 description: DIII-D fusion experiment, via Pelican
 pelican_root: pelican://osg-htc.org:443/fdp-d3d
 origin_server: root://fdp-d3d-origin.nationalresearchplatform.org:8443
-default_llm_preset: amsc
+# The LLM backend/preset is a deployment-level choice (set via
+# $FDP_LLM_BACKEND or ~/.fdp/config.toml [llm].backend), not a per-device
+# one. GA on-prem users select the `amsc` preset there. The `amsc` preset
+# itself is still contributed (toksearch.llm.presets entry point); only the
+# per-device default pointer was removed.
 
 locators:
   - kind: mds_tree

--- a/toksearch_d3d/signal/imas.py
+++ b/toksearch_d3d/signal/imas.py
@@ -586,3 +586,10 @@ class ImasSignal(Signal):
                 pass
         else:
             MdsTreeRegistry().close_all_trees()
+
+
+# Device-prefixed alias for cross-device symmetry with other device packages
+# (e.g. toksearch_mast.MastImasSignal). ``D3dImasSignal`` is exactly
+# equivalent to ``ImasSignal``; the unprefixed name is preserved for
+# backward compatibility.
+D3dImasSignal = ImasSignal


### PR DESCRIPTION
## Summary
- **Env API consumer fix:** `__init__.py`'s eager FDP-env block uses `build_device_config(_resolve_device_handle("d3d"))` (the new `fdp.environment` API; `_resolve_device_env` was removed in GA-FDP/fdp PR #9). DIII-D env byte-for-byte unchanged (`test_env_parity` passes).
- **`D3dImasSignal`:** exact alias of the preserved `ImasSignal`, for `<Device>ImasSignal` symmetry with `toksearch_mast.MastImasSignal`.
- **LLM preset decouple:** drop `default_llm_preset: amsc` from `d3d.yaml` (backend is now deployment-level; the `amsc` preset is still contributed via the `toksearch.llm.presets` entry point).

## Merge/release order
Depends on the new `fdp` env API — release **together with GA-FDP/fdp PR #9**.

## Test Plan
- [x] `import toksearch_d3d` works; `test_d3d_env_matches_captured_fixture` passes (DIII-D env unchanged)
- [x] `D3dImasSignal is ImasSignal`
🤖 Generated with [Claude Code](https://claude.com/claude-code)