### PR TITLE
feat: d3d.yaml uses parent index_dir + json_indexes_* pattern

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -206,7 +206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
-      - conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.0.2-0_595ad62.conda
+      - conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.1.1-0_eb6bcf8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
@@ -353,7 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py312ha7b3241_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.7-py312h738df08_0.conda
+      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.9-py312h738df08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
@@ -3555,12 +3555,12 @@ packages:
   purls: []
   size: 77241
   timestamp: 1777846112704
-- conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.0.2-0_595ad62.conda
+- conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.1.1-0_eb6bcf8.conda
   build_number: 0
-  sha256: c12884c73e82bcefe1ad04daea9fe9f859e1df56dcf138b68dabe20b54631d2c
-  md5: efb88ce7bc0820ea7a151da5062372b1
+  sha256: 9671f2f3c6d1aae2ae7d5a09c57db153282cc2fc27102087da208d57d7afd07c
+  md5: 60876582affe2e2d50498fc5884cc4be
   depends:
-  - xrootd
+  - xrootd <6
   - xrdcl-pelican-fdp
   - certifi
   - __glibc >=2.28,<3.0.a0
@@ -3568,8 +3568,8 @@ packages:
   - libgcc >=15
   - xrootd >=5.9.2,<6.0a0
   license: Apache-2.0
-  size: 131805
-  timestamp: 1778003469510
+  size: 142602
+  timestamp: 1781803431104
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -5891,21 +5891,21 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 225545
   timestamp: 1769678155334
-- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.7-py312h738df08_0.conda
-  sha256: c9eeb636c115333203e8d7af56c9e6ffa3dcdbbaae9d49cf3b8bb1fd9ea206bb
-  md5: 33b335264698dd1573db533b1983fd64
+- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.9-py312h738df08_0.conda
+  sha256: c9483c30b1e4a11874729471211ae52c68c4e597a70034ed66050e122c82ad44
+  md5: 74379b6cfbe4b27a5b41c82baa6a1d5c
   depends:
   - python
   - numpy >=1.20,<2
-  - libfdpio2 >=2.0.2,<3
+  - libfdpio2 >=2.1.1,<3
   - libgfortran
   - __glibc >=2.17,<3.0.a0
   - libfdpio2 >=2.0.0,<3.0.0a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
   license: Apache-2.0
-  size: 2869035
-  timestamp: 1778204468045
+  size: 2882252
+  timestamp: 1781824086832
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -7315,7 +7315,7 @@ packages:
   timestamp: 1780358168616
 - pypi: ./
   name: toksearch-d3d
-  version: 0.9.0+0.gd9df961.dirty
+  version: 0.9.5+6.g62f5408.dirty
   sha256: e4d729b20ca23137c18fde910a61b4e02fefb6120f6c3f0ddd8af32b723b8dc2
   requires_dist:
   - imas-composer ; extra == 'imas'

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ platforms = ["linux-64"]
 [dependencies]
 python = ">=3.11"
 toksearch = ">=2.8.0"
-ptdata = ">=2.0.2,<3"
+ptdata = ">=2.0.9,<3"
 matplotlib = "*"
 imas_composer = ">=0.2"
 # Phase 1 catalog migration. `fdp` is needed for the recipe test step

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - toksearch >=2.8.0
-    - ptdata >=2.0.2,<3
+    - ptdata >=2.0.8,<3
     - imas_composer >=0.2
 
 tests:
@@ -55,7 +55,7 @@ tests:
         # `fdp run` is invoked above; fdp is no longer a release run-dep
         # of toksearch_d3d (Phase 1 catalog migration), but the recipe
         # test driver still needs it. Declared here so the test env has it.
-        - fdp >=0.2.1
+        - fdp >=0.2.4
   # NOTE: removed the `python: imports: - toksearch_d3d` test. It ran
   # `import toksearch_d3d` in a clean env (no FDP env vars set), which
   # triggered libfdpio + libXrdCl load with no XRD_PLUGINCONFDIR, hanging

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - toksearch >=2.8.0
-    - ptdata >=2.0.8,<3
+    - ptdata >=2.0.9,<3
     - imas_composer >=0.2
 
 tests:

--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -89,7 +89,9 @@ ImasSignal (Experimental)
 =========================
 
 Fetches DIII-D data via the IMAS IDS schema using ``imas_composer``.
-Only available when ``imas_composer`` is installed.
+Only available when ``imas_composer`` is installed. Also exported as
+``D3dImasSignal`` (an exact alias) for device-prefixed symmetry with other
+device packages, e.g. ``toksearch_mast.MastImasSignal``.
 
 **Leaf path** — fetches one field::
 
@@ -222,7 +224,7 @@ from .signal.ptdata import RDataSignal
 from .signal.cake import CakeSignal
 
 try:
-    from .signal.imas import ImasSignal, list_imas_fields
+    from .signal.imas import ImasSignal, D3dImasSignal, list_imas_fields
 except ImportError:
     pass
 

--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -209,14 +209,13 @@ _os.environ.setdefault(
     "XRD_PLUGINCONFDIR",
     _os.path.join(_conda_prefix, "etc", "xrootd", "client.plugins.d"),
 )
-from fdp.environment import _generic_config as _fdp_generic_config
+from fdp.environment import build_device_config as _fdp_build_device_config
+from fdp.environment import _resolve_device_handle as _fdp_resolve_device_handle
 from fdp.environment import apply_environment as _fdp_apply_environment
-from fdp.environment import _resolve_device_env as _fdp_resolve_device_env
-_fdp_cfg = _fdp_generic_config()
-_fdp_cfg.update(_fdp_resolve_device_env("d3d"))
+_fdp_cfg = _fdp_build_device_config(_fdp_resolve_device_handle("d3d"))
 _fdp_apply_environment(_fdp_cfg, _os.environ)
 del _os, _sys, _conda_prefix
-del _fdp_generic_config, _fdp_apply_environment, _fdp_resolve_device_env, _fdp_cfg
+del _fdp_build_device_config, _fdp_resolve_device_handle, _fdp_apply_environment, _fdp_cfg
 
 from .signal.ptdata import PtDataSignal
 from .signal.ptdata import RDataSignal

--- a/toksearch_d3d/data/d3d.yaml
+++ b/toksearch_d3d/data/d3d.yaml
@@ -3,7 +3,11 @@ name: d3d
 description: DIII-D fusion experiment, via Pelican
 pelican_root: pelican://osg-htc.org:443/fdp-d3d
 origin_server: root://fdp-d3d-origin.nationalresearchplatform.org:8443
-default_llm_preset: amsc
+# The LLM backend/preset is a deployment-level choice (set via
+# $FDP_LLM_BACKEND or ~/.fdp/config.toml [llm].backend), not a per-device
+# one. GA on-prem users select the `amsc` preset there. The `amsc` preset
+# itself is still contributed (toksearch.llm.presets entry point); only the
+# per-device default pointer was removed.
 
 locators:
   - kind: mds_tree

--- a/toksearch_d3d/data/d3d.yaml
+++ b/toksearch_d3d/data/d3d.yaml
@@ -23,7 +23,8 @@ locators:
   - kind: ptdata_indexed
     name: main
     transport: pelican
-    index_dir: pelican://osg-htc.org:443/fdp-d3d/archives/index/json/json_indexes_2026-01-13_12:22:11
+    index_dir: pelican://osg-htc.org:443/fdp-d3d/archives/index/json
+    index_pattern: "json_indexes_*"
     auth: { kind: bearer_token, env: BEARER_TOKEN }
 
   - kind: sql

--- a/toksearch_d3d/signal/imas.py
+++ b/toksearch_d3d/signal/imas.py
@@ -586,3 +586,10 @@ class ImasSignal(Signal):
                 pass
         else:
             MdsTreeRegistry().close_all_trees()
+
+
+# Device-prefixed alias for cross-device symmetry with other device packages
+# (e.g. toksearch_mast.MastImasSignal). ``D3dImasSignal`` is exactly
+# equivalent to ``ImasSignal``; the unprefixed name is preserved for
+# backward compatibility.
+D3dImasSignal = ImasSignal


### PR DESCRIPTION
## Summary
**This feature (1 commit):**
- `d3d.yaml`: the `ptdata_indexed` locator now uses a parent `index_dir` (`.../archives/index/json`) plus `index_pattern: "json_indexes_*"`, instead of the hardcoded timestamped snapshot dir. The latest snapshot is selected at read time — robust against index updates.

**Also on this branch (prior unmerged work, included per request — full branch):**
- `fix: use fdp build_device_config/_resolve_device_handle` (env API change); `D3dImasSignal` alias of `ImasSignal`; drop per-device `default_llm_preset` from `d3d.yaml`.

## Test Plan
- [x] Cross-repo env-parity (`fdp/tests/test_env_parity.py`) run from this env: **red→green** with the d3d.yaml change (emits parent + `PTDATA_JSON_INDEX_PATTERN=json_indexes_*`).
- [x] Live: a real PTData fetch path resolves the latest `json_indexes_*` snapshot over the federation.

## Cross-repo note
Land **last**: depends on fdp_schema#4, ptdata#26, fdp#10, and libfdpio#6 being published to ga-fdp (in that order) for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)