### PR TITLE
CakeSignal: auto-download CAKE DB from Pelican on first use

### DIFF
--- a/docs/superpowers/plans/2026-06-30-cake-db-autodownload.md
+++ b/docs/superpowers/plans/2026-06-30-cake-db-autodownload.md
@@ -1,0 +1,772 @@
+# CakeSignal CAKE DB Auto-Download Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `CakeSignal` transparently downloads the CAKE DB (`iri_logs.db`) from the Pelican URL already published in `d3d.yaml` to a persistent, process-shared local cache on first instantiation, validating against the remote each run.
+
+**Architecture:** A new isolated helper `toksearch_d3d/signal/_cake_cache.py` exposes one public function `ensure_local_cake_db(source)`. It passes local paths through unchanged and, for remote URLs, maintains a current cached copy under `~/.cache/fdp/cake/` — coordinated across processes with a `filelock` and published atomically with `os.replace`. `CakeSignal.__init__` routes its resolved `cake_db_location` through this helper. Remote stat/download go through two small seams (`_remote_signature`, `_download`) using the XRootD CLI (`xrdfs`/`xrdcp`), which unit tests monkeypatch.
+
+**Tech Stack:** Python 3.11, `unittest`, `filelock`, `sqlite3`, XRootD CLI tools (`xrdfs`, `xrdcp`), `toksearch.MdsSignal`.
+
+---
+
+## Spec
+
+See `docs/superpowers/specs/2026-06-30-cake-db-autodownload-design.md`.
+
+## File Structure
+
+- **Create** `toksearch_d3d/signal/_cake_cache.py` — the cache helper. Pure-ish functions plus the `ensure_local_cake_db` orchestrator. Sole responsibility: turn a (possibly remote) CAKE DB source into a current local path.
+- **Modify** `toksearch_d3d/signal/cake.py` — import and call `ensure_local_cake_db` in `__init__` (one line + one import). Nothing else changes.
+- **Create** `tests/test_cake_cache.py` — unit tests for the helper, no network (seams monkeypatched).
+- **Modify** `tests/test_cake_signal.py` — re-enable a network-gated integration test.
+- **Modify** `pixi.toml` and `recipe/recipe.yaml` — declare `filelock` as a runtime dependency.
+
+---
+
+### Task 1: Scheme detection and cache paths
+
+**Files:**
+- Create: `toksearch_d3d/signal/_cake_cache.py`
+- Test: `tests/test_cake_cache.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cake_cache.py
+import os
+import unittest
+from pathlib import Path
+
+from toksearch_d3d.signal import _cake_cache as cc
+
+
+class TestCachePaths(unittest.TestCase):
+    def test_is_remote_true_for_known_schemes(self):
+        self.assertTrue(cc._is_remote("pelican://h:443/a/iri_logs.db"))
+        self.assertTrue(cc._is_remote("root://h:8443/a/iri_logs.db"))
+        self.assertTrue(cc._is_remote("https://h/a/iri_logs.db"))
+
+    def test_is_remote_false_for_local_path(self):
+        self.assertFalse(cc._is_remote("/tmp/iri_logs.db"))
+        self.assertFalse(cc._is_remote("iri_logs.db"))
+
+    def test_cache_dir_honors_xdg(self):
+        os.environ["XDG_CACHE_HOME"] = "/tmp/xdgcache"
+        try:
+            self.assertEqual(cc._cache_dir(), Path("/tmp/xdgcache/fdp/cake"))
+        finally:
+            del os.environ["XDG_CACHE_HOME"]
+
+    def test_local_path_uses_url_basename(self):
+        os.environ["XDG_CACHE_HOME"] = "/tmp/xdgcache"
+        try:
+            self.assertEqual(
+                cc._local_path("pelican://h:443/fdp-d3d/metadata/iri_logs.db"),
+                Path("/tmp/xdgcache/fdp/cake/iri_logs.db"),
+            )
+        finally:
+            del os.environ["XDG_CACHE_HOME"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && python -m pytest test_cake_cache.py -v`
+Expected: FAIL — `ModuleNotFoundError` / `module 'toksearch_d3d.signal._cake_cache' has no attribute '_is_remote'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# toksearch_d3d/signal/_cake_cache.py
+"""Maintain a process-shared local cache of the CAKE catalogue DB.
+
+`ensure_local_cake_db(source)` turns a (possibly remote) CAKE DB location into a
+current local file path. Local paths pass through unchanged; remote URLs are
+downloaded once to ~/.cache/fdp/cake/ and re-validated against the remote on the
+first call in each process.
+"""
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+_REMOTE_SCHEMES = ("pelican", "root", "http", "https")
+
+
+def _is_remote(source: str) -> bool:
+    return urlparse(source).scheme in _REMOTE_SCHEMES
+
+
+def _cache_dir() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return Path(base) / "fdp" / "cake"
+
+
+def _local_path(source: str) -> Path:
+    return _cache_dir() / os.path.basename(urlparse(source).path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch_d3d/signal/_cake_cache.py tests/test_cake_cache.py
+git commit -m "feat(cake): add cache path + scheme detection helpers"
+```
+
+---
+
+### Task 2: Parse `xrdfs stat` output into a signature
+
+**Files:**
+- Modify: `toksearch_d3d/signal/_cake_cache.py`
+- Test: `tests/test_cake_cache.py`
+
+> `xrdfs <host> stat <path>` prints lines like `Size:   8388608` and
+> `MTime:   2025-05-01 12:00:00`. We extract `Size` (int) and `MTime` (string)
+> as the change-detection signature. (Verify the exact field labels against a
+> live `xrdfs` run during integration; the parser tolerates extra/missing
+> lines.)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+class TestStatParse(unittest.TestCase):
+    SAMPLE = (
+        "Path:   /fdp-d3d/metadata/iri_logs.db\n"
+        "Id:     0001\n"
+        "Size:   8388608\n"
+        "MTime:  2025-05-01 12:00:00\n"
+        "Flags:  16 (IsReadable)\n"
+    )
+
+    def test_parse_extracts_size_and_mtime(self):
+        sig = cc._parse_xrdfs_stat(self.SAMPLE)
+        self.assertEqual(sig["size"], 8388608)
+        self.assertEqual(sig["mtime"], "2025-05-01 12:00:00")
+
+    def test_parse_missing_fields_returns_partial(self):
+        sig = cc._parse_xrdfs_stat("Path: /x\n")
+        self.assertNotIn("size", sig)
+        self.assertNotIn("mtime", sig)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestStatParse -v`
+Expected: FAIL — `module 'toksearch_d3d.signal._cake_cache' has no attribute '_parse_xrdfs_stat'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to toksearch_d3d/signal/_cake_cache.py
+def _parse_xrdfs_stat(output: str) -> dict:
+    """Extract {'size': int, 'mtime': str} from `xrdfs stat` text output."""
+    sig: dict = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Size:"):
+            try:
+                sig["size"] = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("MTime:"):
+            sig["mtime"] = line.split(":", 1)[1].strip()
+    return sig
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestStatParse -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch_d3d/signal/_cake_cache.py tests/test_cake_cache.py
+git commit -m "feat(cake): parse xrdfs stat output into change signature"
+```
+
+---
+
+### Task 3: `ensure_local_cake_db` — local path passthrough
+
+**Files:**
+- Modify: `toksearch_d3d/signal/_cake_cache.py`
+- Test: `tests/test_cake_cache.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+class TestEnsureLocalPassthrough(unittest.TestCase):
+    def test_local_path_returned_unchanged(self):
+        self.assertEqual(cc.ensure_local_cake_db("/data/iri_logs.db"),
+                         "/data/iri_logs.db")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalPassthrough -v`
+Expected: FAIL — `has no attribute 'ensure_local_cake_db'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to toksearch_d3d/signal/_cake_cache.py
+def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
+    """Return a local path to the CAKE DB.
+
+    Local `source` paths are returned unchanged. Remote URLs (pelican://,
+    root://, http(s)://) are cached locally and re-validated; see module docs.
+    """
+    if not _is_remote(source):
+        return source
+    raise NotImplementedError  # remote handling added in Task 4
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalPassthrough -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch_d3d/signal/_cake_cache.py tests/test_cake_cache.py
+git commit -m "feat(cake): ensure_local_cake_db passes local paths through"
+```
+
+---
+
+### Task 4: `ensure_local_cake_db` — remote download to cache
+
+**Files:**
+- Modify: `toksearch_d3d/signal/_cake_cache.py`
+- Test: `tests/test_cake_cache.py`
+
+> Introduces the two seams (`_remote_signature`, `_download`), the sidecar
+> meta, the `filelock`, and atomic publish. Tests monkeypatch the seams and
+> redirect `XDG_CACHE_HOME` to a temp dir, so no network is touched.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+import tempfile
+import shutil
+
+
+class _RemoteFixture:
+    """Helper: a fake remote DB file plus a monkeypatched seam set."""
+    def __init__(self, testcase, contents=b"DBDATA", sig=None):
+        self.dl_calls = 0
+        self.stat_calls = 0
+        self._contents = contents
+        self._sig = sig or {"size": len(contents), "mtime": "2025-05-01 12:00:00"}
+        testcase.tmp = tempfile.mkdtemp()
+        os.environ["XDG_CACHE_HOME"] = testcase.tmp
+        cc._validated.clear()
+        testcase.addCleanup(lambda: shutil.rmtree(testcase.tmp, ignore_errors=True))
+        testcase.addCleanup(lambda: os.environ.pop("XDG_CACHE_HOME", None))
+        testcase.addCleanup(cc._validated.clear)
+
+        def fake_stat(source):
+            self.stat_calls += 1
+            return dict(self._sig)
+
+        def fake_download(source, dest):
+            self.dl_calls += 1
+            Path(dest).write_bytes(self._contents)
+
+        testcase._orig = (cc._remote_signature, cc._download)
+        cc._remote_signature = fake_stat
+        cc._download = fake_download
+        testcase.addCleanup(self._restore, testcase)
+
+    def _restore(self, testcase):
+        cc._remote_signature, cc._download = testcase._orig
+
+    def set_signature(self, sig):
+        self._sig = sig
+
+
+class TestEnsureLocalDownload(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_downloads_and_returns_local_path(self):
+        fx = _RemoteFixture(self)
+        path = cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(path, os.path.join(self.tmp, "fdp/cake/iri_logs.db"))
+        self.assertEqual(Path(path).read_bytes(), b"DBDATA")
+        self.assertEqual(fx.dl_calls, 1)
+
+    def test_writes_sidecar_meta(self):
+        _RemoteFixture(self)
+        path = cc.ensure_local_cake_db(self.URL)
+        meta = Path(path + ".meta.json")
+        self.assertTrue(meta.exists())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalDownload -v`
+Expected: FAIL — `NotImplementedError` (and `_remote_signature`/`_download` not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add imports at top of toksearch_d3d/signal/_cake_cache.py
+import json
+import logging
+import subprocess
+from filelock import FileLock
+
+logger = logging.getLogger(__name__)
+
+_validated: set = set()  # per-process memo of validated source URLs
+
+
+def _split_host_path(url: str):
+    p = urlparse(url)
+    return p.netloc, p.path
+
+
+def _remote_signature(source: str):
+    """Return {'size','mtime'} via `xrdfs <host> stat <path>`, or None on failure."""
+    host, path = _split_host_path(source)
+    try:
+        proc = subprocess.run(
+            ["xrdfs", host, "stat", path],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.warning("xrdfs stat failed for %s: %s", source, exc)
+        return None
+    return _parse_xrdfs_stat(proc.stdout)
+
+
+def _download(source: str, dest: str) -> None:
+    """Copy the remote DB to `dest` with `xrdcp -f`."""
+    subprocess.run(["xrdcp", "-f", source, str(dest)], check=True)
+
+
+def _meta_path(local: Path) -> Path:
+    return local.with_name(local.name + ".meta.json")
+
+
+def _read_meta(local: Path):
+    mp = _meta_path(local)
+    if not mp.exists():
+        return None
+    try:
+        return json.loads(mp.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_meta(local: Path, sig: dict) -> None:
+    _meta_path(local).write_text(json.dumps(sig))
+```
+
+```python
+# replace the body of ensure_local_cake_db with:
+def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
+    """Return a local path to the CAKE DB.
+
+    Local `source` paths are returned unchanged. Remote URLs (pelican://,
+    root://, http(s)://) are cached locally and re-validated; see module docs.
+    """
+    if not _is_remote(source):
+        return source
+
+    if source in _validated and not force:
+        return str(_local_path(source))
+
+    local = _local_path(source)
+    local.parent.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(str(local) + ".lock"):
+        sig = _remote_signature(source)
+        if sig is None:
+            if local.exists():
+                logger.warning("Using cached CAKE DB (remote stat failed): %s", local)
+                _validated.add(source)
+                return str(local)
+            raise RuntimeError(
+                f"Cannot stat remote CAKE DB {source!r} and no local cache "
+                f"exists. Ensure the FDP environment is active (xrdfs/xrdcp on "
+                f"PATH, BEARER_TOKEN set)."
+            )
+        if force or not local.exists() or _read_meta(local) != sig:
+            tmp = local.with_name(f"{local.name}.tmp.{os.getpid()}")
+            _download(source, str(tmp))
+            os.replace(tmp, local)
+            _write_meta(local, sig)
+
+    _validated.add(source)
+    return str(local)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalDownload -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch_d3d/signal/_cake_cache.py tests/test_cake_cache.py
+git commit -m "feat(cake): download remote CAKE DB to shared cache (lock + atomic publish)"
+```
+
+---
+
+### Task 5: Skip / re-download / force based on signature
+
+**Files:**
+- Modify: `tests/test_cake_cache.py` (no implementation change — Task 4 code already covers this; this task verifies it)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+class TestEnsureLocalRefresh(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_unchanged_signature_skips_download_on_new_process(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()  # simulate a fresh process, same cache dir
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)  # signature matched -> no re-download
+
+    def test_changed_signature_redownloads(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()
+        fx.set_signature({"size": 999, "mtime": "2025-06-01 00:00:00"})
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 2)
+
+    def test_force_redownloads_even_when_unchanged(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL, force=True)
+        self.assertEqual(fx.dl_calls, 2)
+```
+
+- [ ] **Step 2: Run test to verify it passes (behavior already implemented)**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalRefresh -v`
+Expected: PASS (3 tests). If any fail, fix `ensure_local_cake_db` in `_cake_cache.py` — do not edit the tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cake_cache.py
+git commit -m "test(cake): cover signature skip/refresh/force behavior"
+```
+
+---
+
+### Task 6: Per-process memoization avoids redundant stats
+
+**Files:**
+- Modify: `tests/test_cake_cache.py` (verifies Task 4 behavior)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+class TestEnsureLocalMemo(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_second_call_same_process_does_not_stat(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.stat_calls, 1)  # memoized after first
+        self.assertEqual(fx.dl_calls, 1)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalMemo -v`
+Expected: PASS. If it fails, fix the memo check in `ensure_local_cake_db` — do not edit the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cake_cache.py
+git commit -m "test(cake): per-process memoization skips redundant stats"
+```
+
+---
+
+### Task 7: Resilience when remote stat fails
+
+**Files:**
+- Modify: `tests/test_cake_cache.py` (verifies Task 4 behavior)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+class TestEnsureLocalResilience(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_stat_fail_with_cache_uses_cache(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)   # populate cache
+        cc._validated.clear()
+        cc._remote_signature = lambda source: None  # remote now unreachable
+        path = cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(Path(path).read_bytes(), b"DBDATA")
+
+    def test_stat_fail_without_cache_raises(self):
+        _RemoteFixture(self)
+        cc._remote_signature = lambda source: None
+        with self.assertRaises(RuntimeError):
+            cc.ensure_local_cake_db(self.URL)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestEnsureLocalResilience -v`
+Expected: PASS (2 tests). If it fails, fix the `sig is None` branch in `ensure_local_cake_db` — do not edit the tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_cake_cache.py
+git commit -m "test(cake): resilience when remote stat fails (use cache / raise)"
+```
+
+---
+
+### Task 8: Wire `ensure_local_cake_db` into `CakeSignal`
+
+**Files:**
+- Modify: `toksearch_d3d/signal/cake.py:1-5` (import) and `toksearch_d3d/signal/cake.py:70-74` (resolution)
+- Test: `tests/test_cake_cache.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cake_cache.py
+from unittest import mock
+
+
+class TestCakeSignalUsesCache(unittest.TestCase):
+    def test_init_routes_db_location_through_cache(self):
+        # A remote URL should be converted to the local cache path during init,
+        # with no MDSplus/network access.
+        with mock.patch(
+            "toksearch_d3d.signal.cake.ensure_local_cake_db",
+            return_value="/cache/iri_logs.db",
+        ) as ensure:
+            from toksearch_d3d import CakeSignal
+            sig = CakeSignal(
+                r"\ipmhd", "eq",
+                cake_db_location="pelican://h:443/fdp-d3d/metadata/iri_logs.db",
+            )
+        ensure.assert_called_once_with(
+            "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+        )
+        self.assertEqual(sig.cake_db_location, "/cache/iri_logs.db")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestCakeSignalUsesCache -v`
+Expected: FAIL — `AttributeError: <module 'toksearch_d3d.signal.cake'> does not have the attribute 'ensure_local_cake_db'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `toksearch_d3d/signal/cake.py`, add the import near the top (after the existing imports on lines 1-5):
+
+```python
+from toksearch_d3d.signal._cake_cache import ensure_local_cake_db
+```
+
+Then change the resolution block (currently lines 70-74):
+
+```python
+        self.cake_db_location = cake_db_location or os.getenv("CAKE_DB_PATH", None)
+
+        if not self.cake_db_location:
+            msg = f"cake_db_location not set"
+            raise Exception(msg)
+```
+
+to:
+
+```python
+        self.cake_db_location = cake_db_location or os.getenv("CAKE_DB_PATH", None)
+
+        if not self.cake_db_location:
+            msg = f"cake_db_location not set"
+            raise Exception(msg)
+
+        # If the location is a remote (e.g. pelican://) URL, download it to a
+        # process-shared local cache and use that path. Local paths pass
+        # through unchanged.
+        self.cake_db_location = ensure_local_cake_db(self.cake_db_location)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && python -m pytest test_cake_cache.py::TestCakeSignalUsesCache -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full helper test module**
+
+Run: `cd tests && python -m pytest test_cake_cache.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toksearch_d3d/signal/cake.py tests/test_cake_cache.py
+git commit -m "feat(cake): CakeSignal auto-downloads remote CAKE DB on init"
+```
+
+---
+
+### Task 9: Declare `filelock` as a runtime dependency
+
+**Files:**
+- Modify: `pixi.toml:20-29` (`[dependencies]`)
+- Modify: `recipe/recipe.yaml:35-39` (`requirements.run`)
+
+- [ ] **Step 1: Add to `pixi.toml`**
+
+Under `[dependencies]` (after the `imas_composer` line, ~line 25), add:
+
+```toml
+filelock = ">=3"
+```
+
+- [ ] **Step 2: Add to `recipe/recipe.yaml`**
+
+Under `requirements: run:` (after `- imas_composer >=0.2`, ~line 39), add:
+
+```yaml
+    - filelock >=3
+```
+
+- [ ] **Step 3: Verify the env still resolves**
+
+Run: `pixi run python -c "import filelock; print(filelock.__version__)"`
+Expected: prints a version `>= 3` (e.g. `3.29.0`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pixi.toml recipe/recipe.yaml
+git commit -m "build(cake): add filelock runtime dependency"
+```
+
+---
+
+### Task 10: Re-enable the gated CakeSignal integration test
+
+**Files:**
+- Modify: `tests/test_cake_signal.py` (replace the commented-out body)
+
+> This is the design's network-gated integration test. It runs only when the
+> FDP environment is active (so `xrdfs`/`xrdcp` and `BEARER_TOKEN` are present),
+> using the real Pelican URL from `d3d.yaml`. Mirrors the
+> `skipTest("requires BEARER_TOKEN ...")` pattern in `test_fdp_decoupling.py`.
+
+- [ ] **Step 1: Replace the file body**
+
+Replace the commented-out block (lines 18-40) of `tests/test_cake_signal.py` with:
+
+```python
+import sqlite3
+
+from toksearch_d3d.signal._cake_cache import ensure_local_cake_db
+
+CAKE_DB_URL = "pelican://osg-htc.org:443/fdp-d3d/metadata/iri_logs.db"
+
+
+class TestCakeDbDownload(unittest.TestCase):
+    """Network-gated: exercises the real Pelican download path."""
+
+    def setUp(self):
+        if os.environ.get("TOKSEARCH_INTEGRATION") != "yes":
+            self.skipTest("integration test (set via testit.py without --mock)")
+        if not (os.environ.get("BEARER_TOKEN") and os.environ.get("CONDA_PREFIX")):
+            self.skipTest("requires BEARER_TOKEN and CONDA_PREFIX (FDP env)")
+
+    def test_downloads_and_opens_blessed_cakes(self):
+        path = ensure_local_cake_db(CAKE_DB_URL, force=True)
+        self.assertTrue(os.path.exists(path))
+        with sqlite3.connect(path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM blessed_cakes")
+            self.assertGreater(cur.fetchone()[0], 0)
+```
+
+- [ ] **Step 2: Run it (skips without FDP env)**
+
+Run: `cd tests && TOKSEARCH_INTEGRATION=no python -m pytest test_cake_signal.py -v`
+Expected: the test is SKIPPED (no error).
+
+- [ ] **Step 3: Run it for real if an FDP env is available**
+
+Run: `pixi run fdp run bash -c 'cd tests && TOKSEARCH_INTEGRATION=yes python -m pytest test_cake_signal.py -v'`
+Expected: PASS — downloads `iri_logs.db` and counts `blessed_cakes` rows. (If no token is available, it SKIPS — acceptable.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_cake_signal.py
+git commit -m "test(cake): re-enable CakeSignal download integration test (gated)"
+```
+
+---
+
+### Task 11: Full suite + manual smoke check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the mocked suite**
+
+Run: `pixi run bash -c 'cd tests && python testit.py --mock --fast-exit'`
+Expected: OK — all unit tests pass, integration tests skipped.
+
+- [ ] **Step 2: Manual smoke (only if an FDP env/token is available)**
+
+Run:
+```bash
+pixi run fdp run python -c "
+from toksearch_d3d import CakeSignal
+s = CakeSignal(r'\\ipmhd', 'eq')   # no cake_db_location -> uses CAKE_DB_PATH from catalog
+print('resolved local db:', s.cake_db_location)
+"
+```
+Expected: prints a path under `~/.cache/fdp/cake/iri_logs.db` (a real local file), not a `pelican://` URL. (Skips/needs a token; acceptable to defer to CI.)
+
+- [ ] **Step 3: Final commit (if any uncommitted verification artifacts)**
+
+```bash
+git status   # expect clean
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** cache location (Task 1), refresh/validate-every-run (Tasks 4–5), URL-already-in-catalog passthrough + remote detection (Tasks 1, 3, 8), per-process memo (Task 6), xrdfs/xrdcp seams (Tasks 2, 4), shared-file concurrency via `filelock` + atomic `os.replace` (Task 4), resilience table (Task 7), `filelock` dependency (Task 9), gated integration test re-enabling `test_cake_signal.py` (Task 10). All covered.
+- **Feasibility fallback** (xrdfs stat may not resolve `pelican://`): surfaced in Task 2's note and exercised by the Task 10 integration run; if `_remote_signature` returns `None` in practice, the Task 7 resilience path keeps things correct (download-once via the cache), and the parser/seam can be adjusted without touching the orchestrator's tests.
+- **Type consistency:** `_remote_signature`/`_download`/`_local_path`/`_read_meta`/`_write_meta`/`_parse_xrdfs_stat`/`ensure_local_cake_db` names and signatures are identical across all tasks and the `CakeSignal` call site.

--- a/docs/superpowers/specs/2026-06-30-cake-db-autodownload-design.md
+++ b/docs/superpowers/specs/2026-06-30-cake-db-autodownload-design.md
@@ -44,7 +44,12 @@ so it "just works" under the standard FDP environment with no manual step.
    sessions.
 2. **Refresh policy:** re-validate against the remote and re-download if it
    changed. The DB grows as new shots are blessed; a stale cache must not go
-   silently out of date.
+   silently out of date. **Change detection compares remote `Size` only**
+   (plus the source URL): the Pelican endpoint returns a volatile `MTime` from
+   `xrdfs stat` (a near-now timestamp that differs on every call, verified
+   2026-06-30), so `mtime` cannot be used to detect change — it is recorded in
+   the sidecar for information but excluded from the comparison. CAKE is
+   append-mostly, so `Size` reliably grows when new shots are blessed.
 3. **URL source:** already solved by the catalog — `CAKE_DB_PATH` in `d3d.yaml`
    `extra_env` carries the Pelican URL. No new locator. The job is to detect
    that the resolved value is a *remote URL* and download it. A plain local path
@@ -104,8 +109,11 @@ Behavior:
   immediately (no network).
 - **Coordinated validate/download**, under a cross-process `filelock`
   (`local + ".lock"`):
-  1. `xrdfs <host> stat <path>` → `(size, mtime)`.
-  2. If the DB is missing, or the stat differs from the sidecar, or `force`:
+  1. `xrdfs <host> stat <path>` → `(size, mtime)` (host keeps the URL scheme,
+     e.g. `pelican://osg-htc.org:443`, or the Pelican plugin won't engage and
+     `xrdfs` hangs; both subprocess calls use a bounded `timeout`).
+  2. If the DB is missing, or the stable staleness key `(size, url)` differs
+     from the sidecar (mtime is recorded but excluded — see decision 2), or `force`:
      `xrdcp -f <source> <tmp>` where `tmp = local + ".tmp.<pid>"`, then
      `os.replace(tmp, local)` (atomic publish), then write the sidecar.
   3. Add `source` to the memo; return `local`.

--- a/docs/superpowers/specs/2026-06-30-cake-db-autodownload-design.md
+++ b/docs/superpowers/specs/2026-06-30-cake-db-autodownload-design.md
@@ -1,0 +1,195 @@
+# CakeSignal CAKE DB auto-download — design
+
+**Date:** 2026-06-30
+**Status:** Approved (pending spec review)
+
+## Problem
+
+`CakeSignal` needs a local SQLite "CAKE catalogue" (`iri_logs.db`, ~8 MB, table
+`BLESSED_CAKES`) to map a shot to its EFIT/OMFIT MDSplus upload IDs. Today the
+class requires the caller to hand it a **local** path via the `cake_db_location`
+argument or the `CAKE_DB_PATH` environment variable, and raises if neither is
+set:
+
+```python
+self.cake_db_location = cake_db_location or os.getenv("CAKE_DB_PATH", None)
+if not self.cake_db_location:
+    raise Exception("cake_db_location not set")
+...
+_conn_cache = sqlite3.connect(self.cake_db_location)
+```
+
+The catalog (`d3d.yaml` `extra_env`) already publishes `CAKE_DB_PATH`, but it
+holds the **Pelican URL**, not a local path:
+
+```yaml
+extra_env:
+  CAKE_DB_PATH: "pelican://osg-htc.org:443/fdp-d3d/metadata/iri_logs.db"
+```
+
+So under `fdp run` / `setup_environment()`, `CakeSignal` receives that URL and
+calls `sqlite3.connect("pelican://…")`, which cannot work — sqlite treats it as
+a literal filename. Users currently have to download the DB by hand (as the
+`fetch_cake_equilibria.py` example script does with `xrdcp` into a
+`tempfile.mkdtemp()`).
+
+**Goal:** `CakeSignal` should transparently download the CAKE DB from Pelican to
+a persistent local cache on first instantiation, and connect to the local copy —
+so it "just works" under the standard FDP environment with no manual step.
+
+## Decisions (from brainstorming)
+
+1. **Cache location:** persistent home dir — `~/.cache/fdp/cake/iri_logs.db`
+   (XDG-aware: honor `$XDG_CACHE_HOME`). Downloaded once, reused across
+   sessions.
+2. **Refresh policy:** re-validate against the remote and re-download if it
+   changed. The DB grows as new shots are blessed; a stale cache must not go
+   silently out of date.
+3. **URL source:** already solved by the catalog — `CAKE_DB_PATH` in `d3d.yaml`
+   `extra_env` carries the Pelican URL. No new locator. The job is to detect
+   that the resolved value is a *remote URL* and download it. A plain local path
+   is still accepted unchanged (back-compat).
+4. **Validation granularity:** once per process, memoized. The first
+   `CakeSignal` in a process stats the remote and conditionally re-downloads; all
+   later instances in that process reuse the validated copy. A fresh run (or a
+   spawned worker) re-validates.
+5. **Fetch mechanism:** XRootD CLI tools (`xrdfs stat` + `xrdcp`) — the same
+   toolchain `fetch_cake_equilibria.py` and the FDP env already provide. No new
+   async/HTTP dependency.
+
+### Why not pelicanfs / fsspec
+
+fsspec's `filecache::`/`simplecache::` would give caching + sharing nearly for
+free, but:
+
+- The project already evaluated **pelicanfs** for ptdata's core path and
+  abandoned it (see `ptdata/debug_pelicanfs.py`, `debug_async.py` — event-loop
+  forensics); ptdata moved to **libfdpio** (C/XRootD). pelicanfs is in no
+  `pixi.toml`/recipe in the stack and is not installed.
+- pelicanfs is async (aiohttp). `CakeSignal` runs inside `compute_multiprocessing`
+  (fork on Linux) and `compute_ray` — fork + a live asyncio event loop is exactly
+  the failure mode those debug scripts chronicle.
+- Auth would need wiring to the FDP `BEARER_TOKEN`; the CLI tools inherit it from
+  the already-configured environment.
+
+For a one-time 8 MB metadata fetch off the hot data path, the CLI-subprocess
+approach is smaller, auth-free, and event-loop-free.
+
+## Architecture
+
+### New isolated unit: `toksearch_d3d/signal/_cake_cache.py`
+
+One public function, independently testable:
+
+```python
+def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
+    """Return a local path to the CAKE DB.
+
+    If `source` is a local file path, return it unchanged. If it is a remote URL
+    (pelican://, root://, http://, https://), ensure a current cached copy exists
+    at ~/.cache/fdp/cake/<basename> and return that local path.
+    """
+```
+
+Behavior:
+
+- **Scheme detection.** Parse `source`. If it has a recognized remote scheme
+  (`pelican`, `root`, `http`, `https`), treat as remote. Otherwise return it
+  unchanged (existing local-path callers and tests are untouched).
+- **Cache path.** `cache_dir = $XDG_CACHE_HOME/fdp/cake` or
+  `~/.cache/fdp/cake`; `local = cache_dir / basename(source)`; sidecar
+  `meta = local + ".meta.json"` records the last-seen remote `{size, mtime, url}`.
+- **Per-process memo.** A module-level `set` of source URLs already validated in
+  this process. If `source` is in it and `force` is False, return `local`
+  immediately (no network).
+- **Coordinated validate/download**, under a cross-process `filelock`
+  (`local + ".lock"`):
+  1. `xrdfs <host> stat <path>` → `(size, mtime)`.
+  2. If the DB is missing, or the stat differs from the sidecar, or `force`:
+     `xrdcp -f <source> <tmp>` where `tmp = local + ".tmp.<pid>"`, then
+     `os.replace(tmp, local)` (atomic publish), then write the sidecar.
+  3. Add `source` to the memo; return `local`.
+- **Resilience.** If the remote stat fails but a cached DB exists → log a warning
+  and use the cache (offline tolerance). If it fails with no cache → raise an
+  informative error naming the URL and required FDP env. `force=True` bypasses
+  the memo and the staleness comparison.
+- **Feasibility fallback.** If `xrdfs stat` cannot resolve `pelican://` URLs in
+  practice, degrade to "download once per process" (memoized, no staleness skip).
+  Still correct; just re-fetches each run instead of skipping on unchanged
+  remote. This is decided during implementation by a real `xrdfs stat` check.
+
+### Host/path parsing
+
+`pelican://osg-htc.org:443/fdp-d3d/metadata/iri_logs.db` →
+host `osg-htc.org:443`, path `/fdp-d3d/metadata/iri_logs.db`. `xrdfs` takes the
+host as its first argument and the path as the stat target. `xrdcp` takes the
+full URL. Both inherit Pelican plugin config and `BEARER_TOKEN` from the env.
+
+### `CakeSignal.__init__` change (minimal)
+
+After the existing resolution of `cake_db_location` (arg → `CAKE_DB_PATH` env,
+unchanged) and the existing "not set" guard, pass the value through the cache:
+
+```python
+self.cake_db_location = ensure_local_cake_db(self.cake_db_location)
+```
+
+Everything downstream — `get_db_conn`, `get_upload_ids`, `gather`, `cleanup` —
+already operates on a local path and is unchanged.
+
+### Concurrency: one shared file for all processes
+
+- **Shared path:** every process on the user/host resolves to the same
+  `~/.cache/fdp/cake/iri_logs.db`.
+- **Cross-process lock** (`filelock`) serializes validate/download: exactly one
+  process downloads; others block, then find the file current and skip.
+- **Atomic publish** (`os.replace`) guarantees no process reads a half-written
+  DB — correctness holds even if locking is imperfect (e.g. NFS home).
+- **Eager + memoized:** the parent builds all `CakeSignal`s before fork and
+  downloads once; forked workers inherit the file and the per-process memo and
+  never re-check. Spawn/Ray workers do at most one `xrdfs stat`, find the file
+  current, and download nothing.
+- **Graceful degradation:** on multi-node Ray over NFS, locking may be
+  best-effort, but atomic replace keeps correctness — worst case a few nodes
+  redundantly fetch 8 MB. No torn reads.
+
+## Error handling summary
+
+| Situation | Behavior |
+|-----------|----------|
+| `source` is a local path | Returned unchanged |
+| Remote, cache absent, download OK | Download, publish, return local |
+| Remote, cache current | Return local (skip download) |
+| Remote stat fails, cache present | Warn, use stale cache |
+| Remote stat fails, no cache | Raise (name URL + required FDP env) |
+| Download fails mid-transfer | Temp file discarded; raise (or use existing cache if present) |
+| `force=True` | Bypass memo + staleness; re-stat and re-download |
+
+## Testing
+
+- **Unit (no network).** Monkeypatch the `xrdfs`/`xrdcp` calls to operate on a
+  local fixture DB:
+  - local path returned as-is;
+  - remote path copies into the cache and returns the local path;
+  - per-process memoization (second call performs no stat);
+  - re-download when the sidecar signature differs;
+  - atomic publish (no partial file observable);
+  - lock serializes two concurrent threads to a single download.
+- **Integration (opt-in, FDP-env gated like the ptdata tests).** Real download
+  of `iri_logs.db`, open it, `SELECT … FROM BLESSED_CAKES`. **Re-enables** the
+  currently-disabled `tests/test_cake_signal.py` in a network-gated form.
+
+## Dependencies
+
+- Add `filelock` to `pyproject.toml` and the rattler-build recipe run-deps
+  (already present in the dev env; make it an explicit dependency).
+- No new async/HTTP dependency. `xrdfs`/`xrdcp` come from the XRootD client
+  already required by the FDP environment.
+
+## Out of scope
+
+- Changing the CAKE DB URL or moving it into a dedicated locator kind — the
+  existing `extra_env: CAKE_DB_PATH` is sufficient.
+- Any change to the MDSplus data path or the upload-ID lookup logic.
+- A general-purpose Pelican download utility for other signal classes (this
+  cache helper is CAKE-specific for now; can be generalized later if needed).

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,6 +23,7 @@ toksearch = ">=2.8.0"
 ptdata = ">=2.0.9,<3"
 matplotlib = "*"
 imas_composer = ">=0.2"
+filelock = ">=3"
 # Phase 1 catalog migration. `fdp` is needed for the recipe test step
 # (which runs `fdp run testit.py`); `fdp-schema` is needed by fdp.catalog.
 fdp = ">=0.2.1"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -37,6 +37,7 @@ requirements:
     - toksearch >=2.8.0
     - ptdata >=2.0.9,<3
     - imas_composer >=0.2
+    - filelock >=3
 
 tests:
   - script:

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -57,3 +57,58 @@ class TestEnsureLocalPassthrough(unittest.TestCase):
     def test_local_path_returned_unchanged(self):
         self.assertEqual(cc.ensure_local_cake_db("/data/iri_logs.db"),
                          "/data/iri_logs.db")
+
+
+import tempfile
+import shutil
+
+
+class _RemoteFixture:
+    """Helper: a fake remote DB file plus a monkeypatched seam set."""
+    def __init__(self, testcase, contents=b"DBDATA", sig=None):
+        self.dl_calls = 0
+        self.stat_calls = 0
+        self._contents = contents
+        self._sig = sig or {"size": len(contents), "mtime": "2025-05-01 12:00:00"}
+        testcase.tmp = tempfile.mkdtemp()
+        os.environ["XDG_CACHE_HOME"] = testcase.tmp
+        cc._validated.clear()
+        testcase.addCleanup(lambda: shutil.rmtree(testcase.tmp, ignore_errors=True))
+        testcase.addCleanup(lambda: os.environ.pop("XDG_CACHE_HOME", None))
+        testcase.addCleanup(cc._validated.clear)
+
+        def fake_stat(source):
+            self.stat_calls += 1
+            return dict(self._sig)
+
+        def fake_download(source, dest):
+            self.dl_calls += 1
+            Path(dest).write_bytes(self._contents)
+
+        testcase._orig = (cc._remote_signature, cc._download)
+        cc._remote_signature = fake_stat
+        cc._download = fake_download
+        testcase.addCleanup(self._restore, testcase)
+
+    def _restore(self, testcase):
+        cc._remote_signature, cc._download = testcase._orig
+
+    def set_signature(self, sig):
+        self._sig = sig
+
+
+class TestEnsureLocalDownload(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_downloads_and_returns_local_path(self):
+        fx = _RemoteFixture(self)
+        path = cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(path, os.path.join(self.tmp, "fdp/cake/iri_logs.db"))
+        self.assertEqual(Path(path).read_bytes(), b"DBDATA")
+        self.assertEqual(fx.dl_calls, 1)
+
+    def test_writes_sidecar_meta(self):
+        _RemoteFixture(self)
+        path = cc.ensure_local_cake_db(self.URL)
+        meta = Path(path + ".meta.json")
+        self.assertTrue(meta.exists())

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from pathlib import Path
+
+from toksearch_d3d.signal import _cake_cache as cc
+
+
+class TestCachePaths(unittest.TestCase):
+    def test_is_remote_true_for_known_schemes(self):
+        self.assertTrue(cc._is_remote("pelican://h:443/a/iri_logs.db"))
+        self.assertTrue(cc._is_remote("root://h:8443/a/iri_logs.db"))
+        self.assertTrue(cc._is_remote("https://h/a/iri_logs.db"))
+
+    def test_is_remote_false_for_local_path(self):
+        self.assertFalse(cc._is_remote("/tmp/iri_logs.db"))
+        self.assertFalse(cc._is_remote("iri_logs.db"))
+
+    def test_cache_dir_honors_xdg(self):
+        os.environ["XDG_CACHE_HOME"] = "/tmp/xdgcache"
+        try:
+            self.assertEqual(cc._cache_dir(), Path("/tmp/xdgcache/fdp/cake"))
+        finally:
+            del os.environ["XDG_CACHE_HOME"]
+
+    def test_local_path_uses_url_basename(self):
+        os.environ["XDG_CACHE_HOME"] = "/tmp/xdgcache"
+        try:
+            self.assertEqual(
+                cc._local_path("pelican://h:443/fdp-d3d/metadata/iri_logs.db"),
+                Path("/tmp/xdgcache/fdp/cake/iri_logs.db"),
+            )
+        finally:
+            del os.environ["XDG_CACHE_HOME"]

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -51,3 +51,9 @@ class TestStatParse(unittest.TestCase):
         sig = cc._parse_xrdfs_stat("Path: /x\n")
         self.assertNotIn("size", sig)
         self.assertNotIn("mtime", sig)
+
+
+class TestEnsureLocalPassthrough(unittest.TestCase):
+    def test_local_path_returned_unchanged(self):
+        self.assertEqual(cc.ensure_local_cake_db("/data/iri_logs.db"),
+                         "/data/iri_logs.db")

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -31,3 +31,23 @@ class TestCachePaths(unittest.TestCase):
             )
         finally:
             del os.environ["XDG_CACHE_HOME"]
+
+
+class TestStatParse(unittest.TestCase):
+    SAMPLE = (
+        "Path:   /fdp-d3d/metadata/iri_logs.db\n"
+        "Id:     0001\n"
+        "Size:   8388608\n"
+        "MTime:  2025-05-01 12:00:00\n"
+        "Flags:  16 (IsReadable)\n"
+    )
+
+    def test_parse_extracts_size_and_mtime(self):
+        sig = cc._parse_xrdfs_stat(self.SAMPLE)
+        self.assertEqual(sig["size"], 8388608)
+        self.assertEqual(sig["mtime"], "2025-05-01 12:00:00")
+
+    def test_parse_missing_fields_returns_partial(self):
+        sig = cc._parse_xrdfs_stat("Path: /x\n")
+        self.assertNotIn("size", sig)
+        self.assertNotIn("mtime", sig)

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -112,3 +112,30 @@ class TestEnsureLocalDownload(unittest.TestCase):
         path = cc.ensure_local_cake_db(self.URL)
         meta = Path(path + ".meta.json")
         self.assertTrue(meta.exists())
+
+
+class TestEnsureLocalRefresh(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_unchanged_signature_skips_download_on_new_process(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()  # simulate a fresh process, same cache dir
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)  # signature matched -> no re-download
+
+    def test_changed_signature_redownloads(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()
+        fx.set_signature({"size": 999, "mtime": "2025-06-01 00:00:00"})
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 2)
+
+    def test_force_redownloads_even_when_unchanged(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL, force=True)
+        self.assertEqual(fx.dl_calls, 2)

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -280,3 +280,37 @@ class TestEnsureLocalConcurrency(unittest.TestCase):
         self.assertEqual(counter["n"], 1)  # FileLock + post-lock check serialized
         self.assertEqual(len(results), 2)
         self.assertEqual(set(results), {os.path.join(self.tmp, "fdp/cake/iri_logs.db")})
+
+
+class TestRemoteSignatureXrdfsInvocation(unittest.TestCase):
+    URL = "pelican://osg-htc.org:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_xrdfs_host_keeps_scheme_and_passes_timeout(self):
+        from unittest import mock
+
+        captured = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return mock.Mock(stdout="Size:   6\nMTime:  2025-05-01 12:00:00\n")
+
+        with mock.patch.object(cc.subprocess, "run", fake_run):
+            sig = cc._remote_signature(self.URL)
+
+        self.assertEqual(
+            captured["argv"],
+            ["xrdfs", "pelican://osg-htc.org:443", "stat",
+             "/fdp-d3d/metadata/iri_logs.db"],
+        )
+        self.assertIn("timeout", captured["kwargs"])
+        self.assertEqual(sig, {"size": 6, "mtime": "2025-05-01 12:00:00"})
+
+    def test_timeout_makes_remote_signature_return_none(self):
+        from unittest import mock
+
+        def fake_run(argv, **kwargs):
+            raise cc.subprocess.TimeoutExpired(cmd=argv, timeout=1)
+
+        with mock.patch.object(cc.subprocess, "run", fake_run):
+            self.assertIsNone(cc._remote_signature(self.URL))

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -224,6 +224,28 @@ class TestEnsureLocalDownloadFailure(unittest.TestCase):
         self.assertEqual(leftovers, [])
 
 
+from unittest import mock
+
+
+class TestCakeSignalUsesCache(unittest.TestCase):
+    def test_init_routes_db_location_through_cache(self):
+        # A remote URL should be converted to the local cache path during init,
+        # with no MDSplus/network access.
+        with mock.patch(
+            "toksearch_d3d.signal.cake.ensure_local_cake_db",
+            return_value="/cache/iri_logs.db",
+        ) as ensure:
+            from toksearch_d3d import CakeSignal
+            sig = CakeSignal(
+                r"\ipmhd", "eq",
+                cake_db_location="pelican://h:443/fdp-d3d/metadata/iri_logs.db",
+            )
+        ensure.assert_called_once_with(
+            "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+        )
+        self.assertEqual(sig.cake_db_location, "/cache/iri_logs.db")
+
+
 class TestEnsureLocalConcurrency(unittest.TestCase):
     URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
 

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -139,3 +139,15 @@ class TestEnsureLocalRefresh(unittest.TestCase):
         cc.ensure_local_cake_db(self.URL)
         cc.ensure_local_cake_db(self.URL, force=True)
         self.assertEqual(fx.dl_calls, 2)
+
+
+class TestEnsureLocalMemo(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_second_call_same_process_does_not_stat(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL)
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.stat_calls, 1)  # memoized after first
+        self.assertEqual(fx.dl_calls, 1)

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -156,6 +156,17 @@ class TestEnsureLocalRefresh(unittest.TestCase):
         cc.ensure_local_cake_db(self.URL, force=True)
         self.assertEqual(fx.dl_calls, 2)
 
+    def test_volatile_mtime_only_does_not_redownload(self):
+        # Pelican returns a near-now (volatile) MTime on every stat. With size
+        # and url unchanged, a differing mtime must NOT trigger a re-download.
+        fx = _RemoteFixture(self, contents=b"DBDATA")
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()  # simulate a fresh process, same cache dir
+        fx.set_signature({"size": len(b"DBDATA"), "mtime": "2099-12-31 23:59:59"})
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)  # mtime ignored -> no re-download
+
 
 class TestEnsureLocalMemo(unittest.TestCase):
     URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -112,6 +112,22 @@ class TestEnsureLocalDownload(unittest.TestCase):
         path = cc.ensure_local_cake_db(self.URL)
         meta = Path(path + ".meta.json")
         self.assertTrue(meta.exists())
+        import json
+        rec = json.loads(meta.read_text())
+        self.assertEqual(rec["url"], self.URL)
+        self.assertIn("size", rec)
+        self.assertIn("mtime", rec)
+
+    def test_different_url_same_basename_redownloads(self):
+        # Same basename (iri_logs.db) + identical size/mtime but a different
+        # source URL must still force a re-download (sidecar records the url).
+        fx = _RemoteFixture(self)
+        other = "pelican://other:443/elsewhere/iri_logs.db"
+        cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(fx.dl_calls, 1)
+        cc._validated.clear()
+        cc.ensure_local_cake_db(other)
+        self.assertEqual(fx.dl_calls, 2)
 
 
 class TestEnsureLocalRefresh(unittest.TestCase):
@@ -169,3 +185,76 @@ class TestEnsureLocalResilience(unittest.TestCase):
         cc._remote_signature = lambda source: None
         with self.assertRaises(RuntimeError):
             cc.ensure_local_cake_db(self.URL)
+
+
+class TestEnsureLocalDownloadFailure(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_download_fail_with_cache_serves_cache(self):
+        fx = _RemoteFixture(self)
+        path = cc.ensure_local_cake_db(self.URL)  # populate cache
+        self.assertEqual(Path(path).read_bytes(), b"DBDATA")
+        # Force a refresh that fails mid-download; a valid cache exists.
+        cc._validated.clear()
+        fx.set_signature({"size": 999, "mtime": "2025-06-01 00:00:00"})
+
+        def boom(source, dest):
+            raise RuntimeError("xrdcp exploded")
+
+        cc._download = boom
+        served = cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(served, path)
+        self.assertEqual(Path(served).read_bytes(), b"DBDATA")
+        # No leftover tmp file.
+        cache = Path(self.tmp) / "fdp" / "cake"
+        leftovers = [p.name for p in cache.iterdir() if ".tmp." in p.name]
+        self.assertEqual(leftovers, [])
+
+    def test_download_fail_without_cache_raises(self):
+        _RemoteFixture(self)
+
+        def boom(source, dest):
+            raise RuntimeError("xrdcp exploded")
+
+        cc._download = boom
+        with self.assertRaises(RuntimeError):
+            cc.ensure_local_cake_db(self.URL)
+        cache = Path(self.tmp) / "fdp" / "cake"
+        leftovers = [p.name for p in cache.iterdir() if ".tmp." in p.name]
+        self.assertEqual(leftovers, [])
+
+
+class TestEnsureLocalConcurrency(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_concurrent_calls_download_once(self):
+        import threading
+        import time
+
+        fx = _RemoteFixture(self)
+        lock = threading.Lock()
+        counter = {"n": 0}
+
+        def slow_download(source, dest):
+            with lock:
+                counter["n"] += 1
+            time.sleep(0.1)
+            Path(dest).write_bytes(b"DBDATA")
+
+        cc._download = slow_download
+
+        results = []
+
+        def worker():
+            results.append(cc.ensure_local_cake_db(self.URL))
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        self.assertEqual(counter["n"], 1)  # FileLock + post-lock check serialized
+        self.assertEqual(len(results), 2)
+        self.assertEqual(set(results), {os.path.join(self.tmp, "fdp/cake/iri_logs.db")})

--- a/tests/test_cake_cache.py
+++ b/tests/test_cake_cache.py
@@ -151,3 +151,21 @@ class TestEnsureLocalMemo(unittest.TestCase):
         cc.ensure_local_cake_db(self.URL)
         self.assertEqual(fx.stat_calls, 1)  # memoized after first
         self.assertEqual(fx.dl_calls, 1)
+
+
+class TestEnsureLocalResilience(unittest.TestCase):
+    URL = "pelican://h:443/fdp-d3d/metadata/iri_logs.db"
+
+    def test_stat_fail_with_cache_uses_cache(self):
+        fx = _RemoteFixture(self)
+        cc.ensure_local_cake_db(self.URL)   # populate cache
+        cc._validated.clear()
+        cc._remote_signature = lambda source: None  # remote now unreachable
+        path = cc.ensure_local_cake_db(self.URL)
+        self.assertEqual(Path(path).read_bytes(), b"DBDATA")
+
+    def test_stat_fail_without_cache_raises(self):
+        _RemoteFixture(self)
+        cc._remote_signature = lambda source: None
+        with self.assertRaises(RuntimeError):
+            cc.ensure_local_cake_db(self.URL)

--- a/tests/test_cake_signal.py
+++ b/tests/test_cake_signal.py
@@ -14,26 +14,26 @@
 
 import unittest
 import os
+import sqlite3
 
-# TODO: CakeSignal tests need to be reworked to use something other than sqlite
-# from toksearch_d3d import CakeSignal
-#
-#
-# class TestCakeSignal(unittest.TestCase):
-#     @classmethod
-#     def setUpClass(cls):
-#         cls.eq_ptname = r"\ipmhd"
-#         cls.prof_ptname = r"\OMFIT_PROFS::TOP:ZEFF"
-#         cls.shot =165920
-#
-#
-#     def test_fetch_eq(self):
-#         results = CakeSignal(self.eq_ptname, "eq").fetch(self.shot)
-#         self.assertGreater(len(results["data"]), 1)
-#         self.assertGreater(len(results["times"]), 1)
-#
-#
-#     def test_fetch_profile(self):
-#         results = CakeSignal(self.prof_ptname, "prof").fetch(self.shot)
-#         self.assertGreater(len(results["data"]), 1)
-#         self.assertGreater(len(results["times"]), 1)
+from toksearch_d3d.signal._cake_cache import ensure_local_cake_db
+
+CAKE_DB_URL = "pelican://osg-htc.org:443/fdp-d3d/metadata/iri_logs.db"
+
+
+class TestCakeDbDownload(unittest.TestCase):
+    """Network-gated: exercises the real Pelican download path."""
+
+    def setUp(self):
+        if os.environ.get("TOKSEARCH_INTEGRATION") != "yes":
+            self.skipTest("integration test (set via testit.py without --mock)")
+        if not (os.environ.get("BEARER_TOKEN") and os.environ.get("CONDA_PREFIX")):
+            self.skipTest("requires BEARER_TOKEN and CONDA_PREFIX (FDP env)")
+
+    def test_downloads_and_opens_blessed_cakes(self):
+        path = ensure_local_cake_db(CAKE_DB_URL, force=True)
+        self.assertTrue(os.path.exists(path))
+        with sqlite3.connect(path) as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM blessed_cakes")
+            self.assertGreater(cur.fetchone()[0], 0)

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -38,6 +38,21 @@ def _split_host_path(url: str):
     return p.netloc, p.path
 
 
+def _parse_xrdfs_stat(output: str) -> dict:
+    """Extract {'size': int, 'mtime': str} from `xrdfs stat` text output."""
+    sig: dict = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Size:"):
+            try:
+                sig["size"] = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("MTime:"):
+            sig["mtime"] = line.split(":", 1)[1].strip()
+    return sig
+
+
 def _remote_signature(source: str):
     """Return {'size','mtime'} via `xrdfs <host> stat <path>`, or None on failure."""
     host, path = _split_host_path(source)
@@ -102,26 +117,30 @@ def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
                 f"exists. Ensure the FDP environment is active (xrdfs/xrdcp on "
                 f"PATH, BEARER_TOKEN set)."
             )
-        if force or not local.exists() or _read_meta(local) != sig:
+        meta = {**sig, "url": source}
+        if force or not local.exists() or _read_meta(local) != meta:
             tmp = local.with_name(f"{local.name}.tmp.{os.getpid()}")
-            _download(source, str(tmp))
-            os.replace(tmp, local)
-            _write_meta(local, sig)
+            try:
+                _download(source, str(tmp))
+                os.replace(tmp, local)
+            except Exception as exc:
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+                if local.exists():
+                    logger.warning(
+                        "Using cached CAKE DB (remote download failed): %s (%s)",
+                        local, exc,
+                    )
+                    _validated.add(source)
+                    return str(local)
+                raise RuntimeError(
+                    f"Failed to download remote CAKE DB {source!r} and no local "
+                    f"cache exists. Ensure the FDP environment is active "
+                    f"(xrdfs/xrdcp on PATH, BEARER_TOKEN set)."
+                ) from exc
+            _write_meta(local, meta)
 
     _validated.add(source)
     return str(local)
-
-
-def _parse_xrdfs_stat(output: str) -> dict:
-    """Extract {'size': int, 'mtime': str} from `xrdfs stat` text output."""
-    sig: dict = {}
-    for line in output.splitlines():
-        line = line.strip()
-        if line.startswith("Size:"):
-            try:
-                sig["size"] = int(line.split(":", 1)[1].strip())
-            except ValueError:
-                pass
-        elif line.startswith("MTime:"):
-            sig["mtime"] = line.split(":", 1)[1].strip()
-    return sig

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -112,6 +112,16 @@ def _write_meta(local: Path, sig: dict) -> None:
     _meta_path(local).write_text(json.dumps(sig))
 
 
+def _staleness_key(meta) -> tuple:
+    """The stable fields used to decide staleness. Endpoint MTime is volatile
+    (Pelican returns a near-now MTime on every stat), so mtime is excluded —
+    only size and source url are compared. CAKE is append-mostly, so size
+    reliably grows when new shots are blessed."""
+    if not meta:
+        return (None, None)
+    return (meta.get("size"), meta.get("url"))
+
+
 def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
     """Return a local path to the CAKE DB.
 
@@ -140,7 +150,8 @@ def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
                 f"PATH, BEARER_TOKEN set)."
             )
         meta = {**sig, "url": source}
-        if force or not local.exists() or _read_meta(local) != meta:
+        if (force or not local.exists()
+                or _staleness_key(_read_meta(local)) != _staleness_key(meta)):
             tmp = local.with_name(f"{local.name}.tmp.{os.getpid()}")
             try:
                 _download(source, str(tmp))

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -25,6 +25,17 @@ def _local_path(source: str) -> Path:
     return _cache_dir() / os.path.basename(urlparse(source).path)
 
 
+def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
+    """Return a local path to the CAKE DB.
+
+    Local `source` paths are returned unchanged. Remote URLs (pelican://,
+    root://, http(s)://) are cached locally and re-validated; see module docs.
+    """
+    if not _is_remote(source):
+        return source
+    raise NotImplementedError  # remote handling added in Task 4
+
+
 def _parse_xrdfs_stat(output: str) -> dict:
     """Extract {'size': int, 'mtime': str} from `xrdfs stat` text output."""
     sig: dict = {}

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -5,11 +5,19 @@ current local file path. Local paths pass through unchanged; remote URLs are
 downloaded once to ~/.cache/fdp/cake/ and re-validated against the remote on the
 first call in each process.
 """
+import json
+import logging
 import os
+import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
+from filelock import FileLock
+
+logger = logging.getLogger(__name__)
 
 _REMOTE_SCHEMES = ("pelican", "root", "http", "https")
+
+_validated: set = set()  # per-process memo of validated source URLs
 
 
 def _is_remote(source: str) -> bool:
@@ -25,6 +33,48 @@ def _local_path(source: str) -> Path:
     return _cache_dir() / os.path.basename(urlparse(source).path)
 
 
+def _split_host_path(url: str):
+    p = urlparse(url)
+    return p.netloc, p.path
+
+
+def _remote_signature(source: str):
+    """Return {'size','mtime'} via `xrdfs <host> stat <path>`, or None on failure."""
+    host, path = _split_host_path(source)
+    try:
+        proc = subprocess.run(
+            ["xrdfs", host, "stat", path],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.warning("xrdfs stat failed for %s: %s", source, exc)
+        return None
+    return _parse_xrdfs_stat(proc.stdout)
+
+
+def _download(source: str, dest: str) -> None:
+    """Copy the remote DB to `dest` with `xrdcp -f`."""
+    subprocess.run(["xrdcp", "-f", source, str(dest)], check=True)
+
+
+def _meta_path(local: Path) -> Path:
+    return local.with_name(local.name + ".meta.json")
+
+
+def _read_meta(local: Path):
+    mp = _meta_path(local)
+    if not mp.exists():
+        return None
+    try:
+        return json.loads(mp.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_meta(local: Path, sig: dict) -> None:
+    _meta_path(local).write_text(json.dumps(sig))
+
+
 def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
     """Return a local path to the CAKE DB.
 
@@ -33,7 +83,33 @@ def ensure_local_cake_db(source: str, *, force: bool = False) -> str:
     """
     if not _is_remote(source):
         return source
-    raise NotImplementedError  # remote handling added in Task 4
+
+    if source in _validated and not force:
+        return str(_local_path(source))
+
+    local = _local_path(source)
+    local.parent.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(str(local) + ".lock"):
+        sig = _remote_signature(source)
+        if sig is None:
+            if local.exists():
+                logger.warning("Using cached CAKE DB (remote stat failed): %s", local)
+                _validated.add(source)
+                return str(local)
+            raise RuntimeError(
+                f"Cannot stat remote CAKE DB {source!r} and no local cache "
+                f"exists. Ensure the FDP environment is active (xrdfs/xrdcp on "
+                f"PATH, BEARER_TOKEN set)."
+            )
+        if force or not local.exists() or _read_meta(local) != sig:
+            tmp = local.with_name(f"{local.name}.tmp.{os.getpid()}")
+            _download(source, str(tmp))
+            os.replace(tmp, local)
+            _write_meta(local, sig)
+
+    _validated.add(source)
+    return str(local)
 
 
 def _parse_xrdfs_stat(output: str) -> dict:

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -1,0 +1,25 @@
+"""Maintain a process-shared local cache of the CAKE catalogue DB.
+
+`ensure_local_cake_db(source)` turns a (possibly remote) CAKE DB location into a
+current local file path. Local paths pass through unchanged; remote URLs are
+downloaded once to ~/.cache/fdp/cake/ and re-validated against the remote on the
+first call in each process.
+"""
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+_REMOTE_SCHEMES = ("pelican", "root", "http", "https")
+
+
+def _is_remote(source: str) -> bool:
+    return urlparse(source).scheme in _REMOTE_SCHEMES
+
+
+def _cache_dir() -> Path:
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return Path(base) / "fdp" / "cake"
+
+
+def _local_path(source: str) -> Path:
+    return _cache_dir() / os.path.basename(urlparse(source).path)

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -23,3 +23,18 @@ def _cache_dir() -> Path:
 
 def _local_path(source: str) -> Path:
     return _cache_dir() / os.path.basename(urlparse(source).path)
+
+
+def _parse_xrdfs_stat(output: str) -> dict:
+    """Extract {'size': int, 'mtime': str} from `xrdfs stat` text output."""
+    sig: dict = {}
+    for line in output.splitlines():
+        line = line.strip()
+        if line.startswith("Size:"):
+            try:
+                sig["size"] = int(line.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        elif line.startswith("MTime:"):
+            sig["mtime"] = line.split(":", 1)[1].strip()
+    return sig

--- a/toksearch_d3d/signal/_cake_cache.py
+++ b/toksearch_d3d/signal/_cake_cache.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 _REMOTE_SCHEMES = ("pelican", "root", "http", "https")
 
+# Bounded timeouts so a stalled xrdfs/xrdcp cannot wedge the process forever;
+# without these the resilience fallback (stat fails -> serve cache / raise) can
+# never fire.
+_STAT_TIMEOUT_S = 30
+_DOWNLOAD_TIMEOUT_S = 600
+
 _validated: set = set()  # per-process memo of validated source URLs
 
 
@@ -34,8 +40,15 @@ def _local_path(source: str) -> Path:
 
 
 def _split_host_path(url: str):
+    """Return (host, path) for xrdfs.
+
+    The host MUST retain the URL scheme (e.g. ``pelican://osg-htc.org:443``) so
+    the Pelican client plugin engages — it matches on the scheme. Dropping the
+    scheme makes xrdfs fall back to ``root://`` against the HTTPS director port
+    and hang indefinitely.
+    """
     p = urlparse(url)
-    return p.netloc, p.path
+    return f"{p.scheme}://{p.netloc}", p.path
 
 
 def _parse_xrdfs_stat(output: str) -> dict:
@@ -60,8 +73,13 @@ def _remote_signature(source: str):
         proc = subprocess.run(
             ["xrdfs", host, "stat", path],
             capture_output=True, text=True, check=True,
+            timeout=_STAT_TIMEOUT_S,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as exc:
         logger.warning("xrdfs stat failed for %s: %s", source, exc)
         return None
     return _parse_xrdfs_stat(proc.stdout)
@@ -69,7 +87,11 @@ def _remote_signature(source: str):
 
 def _download(source: str, dest: str) -> None:
     """Copy the remote DB to `dest` with `xrdcp -f`."""
-    subprocess.run(["xrdcp", "-f", source, str(dest)], check=True)
+    subprocess.run(
+        ["xrdcp", "-f", source, str(dest)],
+        check=True,
+        timeout=_DOWNLOAD_TIMEOUT_S,
+    )
 
 
 def _meta_path(local: Path) -> Path:

--- a/toksearch_d3d/signal/cake.py
+++ b/toksearch_d3d/signal/cake.py
@@ -3,6 +3,7 @@ import sqlite3
 from contextlib import closing
 from toksearch import MdsSignal, MdsTreePath
 from typing import Optional, Union, Iterable
+from toksearch_d3d.signal._cake_cache import ensure_local_cake_db
 
 _conn_cache = None
 
@@ -72,6 +73,11 @@ class CakeSignal(MdsSignal):
         if not self.cake_db_location:
             msg = f"cake_db_location not set"
             raise Exception(msg)
+
+        # If the location is a remote (e.g. pelican://) URL, download it to a
+        # process-shared local cache and use that path. Local paths pass
+        # through unchanged.
+        self.cake_db_location = ensure_local_cake_db(self.cake_db_location)
 
     def get_db_conn(self) -> sqlite3.Connection:
         # Use self.cake_db_location to get connection.


### PR DESCRIPTION
## Summary

`CakeSignal` no longer requires a local SQLite path. It now transparently downloads the CAKE catalogue DB (`iri_logs.db`) from the Pelican URL already published in `d3d.yaml` (`CAKE_DB_PATH`) to a persistent, process-shared cache on first instantiation, and connects to the local copy. Under `fdp run` it "just works" with no manual `xrdcp` step.

- **New helper** `toksearch_d3d/signal/_cake_cache.py` — `ensure_local_cake_db(source, *, force=False)`. Local paths pass through unchanged (back-compat); remote URLs (`pelican://`, `root://`, `http(s)://`) are cached at `~/.cache/fdp/cake/` (XDG-aware).
- **Process-shared & concurrency-safe** — one shared file for all processes via a cross-process `filelock` + atomic `os.replace` publish; validated against the remote once per process (memoized), so a fork-based pipeline downloads once and workers inherit it.
- **`CakeSignal.__init__`** routes its resolved `cake_db_location` through the helper (one import + one line); `get_db_conn`/`gather`/`cleanup` unchanged.
- **Resilience** — remote stat/download failure serves an existing cache (warn) or raises an actionable error naming the URL + required FDP env.
- Adds `filelock >=3` to `pixi.toml` and `recipe/recipe.yaml`; re-enables `tests/test_cake_signal.py` as a network-gated integration test.

Fetch path uses the XRootD CLI (`xrdfs stat` + `xrdcp`), matching the existing `fetch_cake_equilibria.py` precedent — deliberately not `pelicanfs` (async/fork-fragile; previously abandoned in `ptdata`).

## Notable issues found & fixed during review

- **CRITICAL (init hang):** the `xrdfs` host arg must retain the `pelican://` scheme or the Pelican plugin never engages and `xrdfs` hangs against the HTTPS director port. Fixed + regression test.
- **CRITICAL (resilience):** added bounded `timeout=` to both subprocess calls so a stalled stat/transfer degrades to the fallback instead of wedging `__init__`.
- **Staleness signal:** the endpoint returns a volatile `MTime` (near-now on every stat), so change detection compares **stable `Size` (+ url) only** (mtime kept in the sidecar for info). CAKE is append-mostly, so size reliably grows on change.

## Test plan

- [x] `pixi run python -m pytest tests/test_cake_cache.py` → **23 passed** (incl. concurrency, resilience, xrdfs-host/timeout, and volatile-mtime regression tests).
- [x] Token-backed integration run (live endpoint): `TestCakeDbDownload` **passed** — real `iri_logs.db` downloaded, opened, `SELECT COUNT(*) FROM blessed_cakes > 0`.
- [x] Verified the skip-when-unchanged path live: a second fresh process returns in 0.42s with no re-download (local file mtime unchanged).
- [ ] CI full integration suite under `fdp run` (build-env token).

Specs/plan: `docs/superpowers/{specs,plans}/2026-06-30-cake-db-autodownload*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)