### PR TITLE
build: bump ptdata floor to >=2.0.11

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - toksearch >=2.8.0
-    - ptdata >=2.0.9,<3
+    - ptdata >=2.0.11,<3
     - imas_composer >=0.2
     - filelock >=3
     # CakeSignal fetches the CAKE DB by shelling out to the `pelican` CLI


### PR DESCRIPTION
## Summary

Bump the `ptdata` run-dep floor from `>=2.0.9,<3` to `>=2.0.11,<3`. ptdata 2.0.11 restores the legacy `PTSEARCH0` multi-extension shotfile search that the 2.0.0 rewrite dropped — without it, simulation/PCS shots with no `.PLA` master (fetched via `PtDataSignal` over local `SYS_D3`) fail with `Shot <shot>.PLA not found`. Flooring the dep ensures a standalone `conda install toksearch_d3d` pulls a fixed ptdata.

Ships as toksearch_d3d 0.9.9 (versioneer tag-driven).

## Test Plan
- [x] Recipe-only change; conda build/test matrix in CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)