### PR TITLE
build: bump toksearch floor to >=2.8.1

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,7 +34,7 @@ requirements:
     - versioneer
   run:
     - python
-    - toksearch >=2.8.0
+    - toksearch >=2.8.1
     - ptdata >=2.0.11,<3
     - imas_composer >=0.2
     - filelock >=3


### PR DESCRIPTION
## Summary

Bump the `toksearch` run-dep floor `>=2.8.0` → `>=2.8.1`.

toksearch 2.8.1 lazy-loads the Ray/Spark backends, cutting `import toksearch` from ~4.4s to ~1.4s (~3×). Raising the floor ensures `toksearch_d3d` installs pull the faster import.

Non-breaking: 2.8.1 is a perf + bugfix release with no API change.

## Test Plan
- [x] Recipe-only change; conda build + upload on the `release-0.9.10` tag will validate the solve against ga-fdp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)