### PR TITLE
feat(PtDataSignal): single-fetch via PtDataReader + per-process reader reuse

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -353,7 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py312ha7b3241_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.9-py312h738df08_0.conda
+      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.13-py312h738df08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
@@ -5891,21 +5891,21 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 225545
   timestamp: 1769678155334
-- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.9-py312h738df08_0.conda
-  sha256: c9483c30b1e4a11874729471211ae52c68c4e597a70034ed66050e122c82ad44
-  md5: 74379b6cfbe4b27a5b41c82baa6a1d5c
+- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.13-py312h738df08_0.conda
+  sha256: 845f670bc3f2b95816766b1da968ea7303f512ab85631787bdd287deec7b3215
+  md5: fec05edd2afa612d4b581263b016acd7
   depends:
   - python
   - numpy >=1.20,<2
   - libfdpio2 >=2.1.1,<3
   - libgfortran
   - __glibc >=2.17,<3.0.a0
-  - libfdpio2 >=2.0.0,<3.0.0a0
-  - python_abi 3.12.* *_cp312
   - numpy >=1.26.4,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - libfdpio2 >=2.0.0,<3.0.0a0
   license: Apache-2.0
-  size: 2882252
-  timestamp: 1781824086832
+  size: 2899098
+  timestamp: 1784566361744
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -7315,7 +7315,7 @@ packages:
   timestamp: 1780358168616
 - pypi: ./
   name: toksearch-d3d
-  version: 0.9.5+6.g62f5408.dirty
+  version: 0.9.10+0.ge9f8cca.dirty
   sha256: e4d729b20ca23137c18fde910a61b4e02fefb6120f6c3f0ddd8af32b723b8dc2
   requires_dist:
   - imas-composer ; extra == 'imas'

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ platforms = ["linux-64"]
 [dependencies]
 python = ">=3.11"
 toksearch = ">=2.8.0"
-ptdata = ">=2.0.9,<3"
+ptdata = ">=2.0.13,<3"
 matplotlib = "*"
 imas_composer = ">=0.2"
 filelock = ">=3"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - toksearch >=2.8.1
-    - ptdata >=2.0.11,<3
+    - ptdata >=2.0.13,<3
     - imas_composer >=0.2
     - filelock >=3
     # CakeSignal fetches the CAKE DB by shelling out to the `pelican` CLI

--- a/tests/test_ptdata_signal_reader_reuse.py
+++ b/tests/test_ptdata_signal_reader_reuse.py
@@ -1,0 +1,102 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PtDataSignal now fetches via the modern PtDataReader and reuses one reader
+per process (a PtDataReaderRegistry singleton), so a pipeline of many shots
+issues a single fetch per shot on one shared, pooled ptserver connection —
+instead of the legacy PtDataFetcher's per-shot reader + separate header read.
+
+These tests pin the reuse/lifecycle contract. Data-correctness/units parity is
+covered by test_ptdata_signal.py.
+"""
+
+import os
+import pickle
+import unittest
+
+from toksearch_d3d.signal.ptdata import PtDataSignal, PtDataReaderRegistry
+
+TEST_SHOTS = os.environ.get(
+    "PTDATA_TEST_SHOTS_DIR", "/cscratch/sammuli/ptdata_test_files")
+
+
+def _shots_available():
+    return os.path.isfile(os.path.join(TEST_SHOTS, "165920.MAG"))
+
+
+@unittest.skipUnless(_shots_available(),
+                     f"local test shots not found at {TEST_SHOTS}")
+class TestPtDataReaderReuse(unittest.TestCase):
+    SHOT = 165920
+    PTNAME = "ip"
+
+    def setUp(self):
+        self._env_backup = {k: os.environ.get(k)
+                            for k in ("SYS_D3", "SYS_D3_DELIM")}
+        os.environ["SYS_D3"] = TEST_SHOTS
+        os.environ["SYS_D3_DELIM"] = ";"
+        PtDataReaderRegistry().close()  # test isolation
+
+    def tearDown(self):
+        PtDataReaderRegistry().close()
+        for k, v in self._env_backup.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_registry_is_singleton(self):
+        self.assertIs(PtDataReaderRegistry(), PtDataReaderRegistry())
+
+    def test_reader_created_lazily(self):
+        # No reader until the first gather.
+        self.assertIsNone(PtDataReaderRegistry()._reader)
+        PtDataSignal(self.PTNAME).fetch(self.SHOT)
+        self.assertIsNotNone(PtDataReaderRegistry()._reader)
+
+    def test_reader_reused_across_fetches(self):
+        sig = PtDataSignal(self.PTNAME)
+        sig.fetch(self.SHOT)
+        r1 = PtDataReaderRegistry().reader()
+        sig.fetch(self.SHOT)
+        r2 = PtDataReaderRegistry().reader()
+        self.assertIs(r1, r2)
+
+    def test_distinct_signals_share_one_reader(self):
+        # Two independent Signal instances must share the one process reader.
+        PtDataSignal(self.PTNAME).fetch(self.SHOT)
+        r1 = PtDataReaderRegistry().reader()
+        PtDataSignal(self.PTNAME).fetch(self.SHOT)
+        r2 = PtDataReaderRegistry().reader()
+        self.assertIs(r1, r2)
+
+    def test_cleanup_releases_reader(self):
+        sig = PtDataSignal(self.PTNAME)
+        sig.fetch(self.SHOT)
+        self.assertIsNotNone(PtDataReaderRegistry()._reader)
+        sig.cleanup()
+        self.assertIsNone(PtDataReaderRegistry()._reader)
+
+
+class TestPtDataSignalPicklable(unittest.TestCase):
+    """The design keeps the (unpicklable) reader off the Signal so Signals can
+    be shipped to multiprocessing/Ray workers. This runs without shot files."""
+
+    def test_signal_is_picklable_and_holds_no_reader(self):
+        sig = PtDataSignal("ip", ical=4, fetch_times=False)
+        self.assertFalse(hasattr(sig, "_reader"))
+        restored = pickle.loads(pickle.dumps(sig))
+        self.assertEqual(restored.pointname, "ip")
+        self.assertEqual(restored.ical, 4)
+        self.assertFalse(restored.fetch_times)

--- a/toksearch_d3d/signal/ptdata.py
+++ b/toksearch_d3d/signal/ptdata.py
@@ -1,37 +1,107 @@
 # Copyright 2024 General Atomics
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import warnings
+
+import numpy as np
+
 from toksearch import Signal
 from toksearch.utilities.utilities import set_env
-from ptdata import PtDataFetcher
+
+import ptdata
+from ptdata import _core
+
+
+# Legacy `ical` flag -> engine CalibrationMode. Mirrors ptdata.fetch._ICAL_MAP.
+_ICAL_MAP = {
+    0: _core.CalibrationMode.Raw,
+    1: _core.CalibrationMode.Full,
+    4: _core.CalibrationMode.Linear,
+}
+
+
+class PtDataReaderRegistry:
+    """Process-global holder for a single shared ``ptdata.PtDataReader``.
+
+    All ``PtDataSignal`` instances in a worker fetch through one reader, so the
+    underlying ptserver connection (pooled inside ptdata >= 2.0.13) is reused
+    across shots instead of re-dialed per fetch. The reader lives here rather
+    than on the Signal instance so Signals stay picklable for
+    multiprocessing/Ray workers -- the same pattern as
+    ``toksearch.signal.mds.MdsTreeRegistry``.
+
+    Pid-guarded: a forked worker gets a fresh registry (and rebuilds its own
+    reader) rather than inheriting the parent's, mirroring
+    ``toksearch.signal.SignalRegistry``. A reader carried across ``fork()``
+    would be unsafe -- libfdpio (XrdCl + libcurl) is not fork-safe.
+    """
+
+    __instance = None
+
+    def __new__(cls):
+        inst = PtDataReaderRegistry.__instance
+        pid = os.getpid()
+        if inst is None or inst._pid != pid:
+            inst = object.__new__(cls)
+            inst._reader = None
+            inst._pid = pid
+            PtDataReaderRegistry.__instance = inst
+        return inst
+
+    def reader(self):
+        """Return the shared reader, constructing it on first use.
+
+        The reader captures its configuration from the environment
+        (``SYS_D3``, ``PTDATA_JSON_INDEX_DIR``/``PTDATA_PLUGIN_LIB``,
+        ``PTDATA_PTSERVERS``) at construction and reuses it until
+        :meth:`close`; a mid-process env change only takes effect on the next
+        chunk (after ``cleanup()``). Fine under ``fdp run``, where the
+        environment is fixed per process.
+        """
+        if self._reader is None:
+            self._reader = ptdata.PtDataReader()
+        return self._reader
+
+    def close(self):
+        """Drop the shared reader. The pooled ptserver connection is owned by
+        ptdata's process-global pool, so it survives for other users and is
+        released at process exit."""
+        self._reader = None
 
 
 class PtDataSignal(Signal):
     """Fetch a DIII-D PTDATA diagnostic as a toksearch Signal.
 
-    Wraps `ptdata.PtDataFetcher` and exposes the result through the standard
-    Signal interface.  Times are in milliseconds.
+    Fetches through the modern ``ptdata.PtDataReader`` (shared per process via
+    ``PtDataReaderRegistry``): a single ``fetch`` yields data, times, and units
+    together, so there is one ptserver round-trip per shot rather than the
+    legacy ``PtDataFetcher``'s separate header read + data fetch. Times are in
+    milliseconds.
 
     Args:
         pointname: PTDATA point name (case-insensitive), e.g. `'ip'`.
-        remote: If True (default), sets `PTDATA_LOC=1` for the fetch,
-            routing to the Pelican/OSDF remote store.  If False, sets
-            `PTDATA_LOC=0`, forcing local ptserver (athena) access.
-        ical: Calibration flag passed to `PtDataFetcher`.  `1` (default)
-            returns calibrated data; `0` returns raw counts.
-        keep_header: If True, include the raw PTDATA header dict in the
-            result under the `'header'` key.
+        remote: Retained for backward compatibility; sets `PTDATA_LOC` for the
+            fetch. NOTE: `PTDATA_LOC` is a no-op in the ptdata 2.0 engine —
+            routing (Pelican index vs local files vs ptserver/athena) is
+            determined by the environment (`PTDATA_JSON_INDEX_DIR`, `SYS_D3`,
+            `PTDATA_PTSERVERS`) set up by `fdp`, not by this flag.
+        ical: Calibration flag.  `1` (default) returns calibrated data;
+            `0` returns raw counts; `4` applies linear calibration.
+        keep_header: If True, include the raw PTDATA header (a
+            `ptdata.PtDataHeader`) in the result under the `'header'` key.
+            Note: this incurs an extra header read.
         fetch_times: If True (default), include a `'times'` array
             (milliseconds) in the result.
         fetch_units: If True (default), include a `'units'` dict in the
@@ -64,16 +134,39 @@ class PtDataSignal(Signal):
 
         ptdata_loc = '1' if self.remote else '0'
         with set_env('PTDATA_LOC', ptdata_loc):
-            fetcher = PtDataFetcher(self.pointname, shot)
-            results = fetcher.fetch(fetch_times=fetch_times, ical=self.ical)
+            reader = PtDataReaderRegistry().reader()
+
+            params = _core.ExtractionParams()
+            params.fetch_times = fetch_times
+            params.calibration = _ICAL_MAP.get(self.ical, _core.CalibrationMode.Full)
+
+            result = reader.fetch(self.pointname, int(shot), params)
+
+            # Raw calibration populates raw_integer rather than data; fall
+            # through so 'data' is non-empty regardless of mode (matches the
+            # legacy fetch_ptdata contract).
+            data_source = result.data if len(result.data) > 0 else result.raw_integer
+            results = {
+                "data": np.array(data_source),
+                "n_over": result.n_over,
+                "n_under": result.n_under,
+            }
+            if fetch_times and len(result.times) > 0:
+                results["times"] = np.array(result.times)
 
             if self.keep_header:
-                results["header"] = fetcher.header
+                # Opt-in: the header is not part of the single fetch, so this
+                # costs one extra read. PtDataHeader is deprecated but returned
+                # verbatim for output parity; suppress its per-call warning.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    results["header"] = ptdata.PtDataHeader(self.pointname, int(shot))
 
             if fetch_units:
                 results["units"] = {}
-                encoding = "utf-8"
-                results["units"]["data"] = fetcher.units().decode(encoding)
+                # ExtractedData.units is the raw 4-char field; match the legacy
+                # PtDataHeader.units() normalization (lowercased, trimmed).
+                results["units"]["data"] = result.units.strip().lower()
                 if fetch_times:
                     results["units"][dims[0]] = "ms"
 
@@ -84,7 +177,7 @@ class PtDataSignal(Signal):
         pass
 
     def cleanup(self):
-        pass
+        PtDataReaderRegistry().close()
 
 class RDataSignal(PtDataSignal):
     """Fetch the RDATA point from PTDATA as a toksearch Signal.


### PR DESCRIPTION
## Summary

`PtDataSignal` fetched through the deprecated `ptdata.PtDataFetcher`, which built a fresh reader per shot and made **two** ptserver round-trips per fetch — an eager header read (`PtDataHeader.__init__`) plus the data fetch. It now fetches through the modern `ptdata.PtDataReader`: a single `fetch()` returns data + times + units together (units via the new `ExtractedData.units`, ptdata 2.0.13), so it's **one round-trip per shot**.

The reader is shared per process via a `PtDataReaderRegistry` singleton (mirroring `toksearch.signal.mds.MdsTreeRegistry`), so every signal in a worker reuses one reader over one pooled ptserver connection instead of reconstructing per shot. The reader lives in the registry (not on the Signal), so Signals stay picklable for multiprocessing/Ray workers; `cleanup()` releases it. The registry is **pid-guarded** — a forked worker rebuilds its own reader (libfdpio isn't fork-safe).

Bumps the `ptdata` floor to `>=2.0.13` (requires `ExtractedData.units`) in `pixi.toml` and `recipe/recipe.yaml`.

## Behavior

Output-contract parity is preserved (data/n_over/n_under/times/units/header) — covered by the existing `test_ptdata_signal.py`. The `remote` flag is retained but its docstring is corrected: `PTDATA_LOC` is a no-op in the ptdata 2.0 engine (routing is env-driven), so the flag no longer changes routing.

## Test plan

- New `tests/test_ptdata_signal_reader_reuse.py`: registry singleton, lazy creation, reader reuse across fetches and across distinct Signal instances, `cleanup()` release, and an unconditional picklability test.
- Existing `test_ptdata_signal.py` passes (parity) for locally-resolvable pointnames.
- Verified end-to-end: `compute_multiprocessing` over multiple shots returns correct data/units; pid-guard verified by building the reader in the parent before forking workers (workers rebuild, no hang).
- Code-reviewed; review items addressed (honest `remote` docstring, pid-guard, env-binding note, `keep_header` warning suppression, pickling + env-restore tests).

## Notes / follow-ups (pre-existing, not introduced here)

- `keep_header=True` returns a `ptdata.PtDataHeader` (wraps an unpicklable `_core.PointData`), so it doesn't round-trip through multiprocessing — same as before this change. Left as-is for output parity.
- `PTDATA_LOC` being a no-op in the ptdata 2.0 engine (so `remote=False` doesn't force local access) is a separate latent issue, now documented honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)