### PR TITLE
fix(ImasSignal): label channel-indexed data with a times coordinate in fetch_as_xarray

### DIFF
--- a/tests/test_imas_signal.py
+++ b/tests/test_imas_signal.py
@@ -306,6 +306,14 @@ class TestImasSignalMagnetics(unittest.TestCase):
         self.assertEqual(result['times'].ndim, 2)
         self.assertGreater(result['times'].max(), 100.0)
 
+    def test_ip_data_fetch_as_xarray_times_coord(self):
+        """fetch_as_xarray squeezes the singleton measurement axis and
+        attaches a times coordinate, so align() works on magnetics.ip.data."""
+        sig = self.ImasSignal('magnetics.ip.data', composer=self.composer)
+        da = sig.fetch_as_xarray(SHOT_MAGNETICS)
+        self.assertEqual(da.dims, ('times',))
+        self.assertGreater(da['times'].values.max(), 100.0)
+
     def test_diamagnetic_flux_shape(self):
         """magnetics.diamagnetic_flux.data is (n_measurements, n_time); DIII-D has 1."""
         result = self._gather('magnetics.diamagnetic_flux.data')
@@ -605,3 +613,69 @@ class TestImasSignalAsAwkward(unittest.TestCase):
         result = sig.gather(SHOT)
         for val in result.values():
             self.assertIsInstance(val, (ak.Array, np.ndarray))
+
+
+class _FakeLeafComposer:
+    """Stand-in composer for unit tests of xarray conversion (no network)."""
+
+    def __init__(self, ids_path):
+        self._ids_path = ids_path
+
+    def get_supported_fields(self, ids_path):
+        return [self._ids_path]
+
+
+class TestImasSignalFetchAsXarrayChannelDims(unittest.TestCase):
+    """fetch_as_xarray must attach a times coordinate to channel-indexed data.
+
+    Channel-indexed leaves (e.g. magnetics.ip.data) gather as data (n_chan, N)
+    with times also (n_chan, N). When the per-channel timebases are identical,
+    the DataArray must get a real 'times' coordinate; a singleton channel axis
+    must be squeezed so the result behaves like a plain 1-D signal.
+    """
+
+    def _signal_with_gather(self, result):
+        from toksearch_d3d import ImasSignal
+        sig = ImasSignal('fake.path', composer=_FakeLeafComposer('fake.path'))
+        sig.gather = lambda shot: result
+        return sig
+
+    def test_single_channel_2d_squeezed_with_times_coord(self):
+        """(1, N) data + (1, N) times -> 1-D DataArray with times coordinate."""
+        times = np.arange(5, dtype=float)
+        data = np.arange(5, dtype=float)[np.newaxis, :] * 2.0
+        sig = self._signal_with_gather({'data': data, 'times': times[np.newaxis, :]})
+        da = sig.fetch_as_xarray(0)
+        self.assertEqual(da.dims, ('times',))
+        np.testing.assert_array_equal(da['times'].values, times)
+        np.testing.assert_array_equal(da.values, data[0])
+
+    def test_multichannel_identical_times_get_times_coord(self):
+        """(3, N) data with identical per-channel times keeps the channel axis
+        but labels the time axis with a times coordinate."""
+        times = np.arange(4, dtype=float)
+        data = np.arange(12, dtype=float).reshape(3, 4)
+        times_2d = np.tile(times, (3, 1))
+        sig = self._signal_with_gather({'data': data, 'times': times_2d})
+        da = sig.fetch_as_xarray(0)
+        self.assertEqual(da.shape, (3, 4))
+        self.assertIn('times', da.dims)
+        np.testing.assert_array_equal(da['times'].values, times)
+
+    def test_multichannel_ragged_times_left_unlabeled(self):
+        """Differing per-channel timebases cannot be a shared coordinate;
+        generic dim labels and no times coordinate (existing behavior)."""
+        data = np.arange(8, dtype=float).reshape(2, 4)
+        times_2d = np.stack([np.arange(4.0), np.arange(4.0) + 0.5])
+        sig = self._signal_with_gather({'data': data, 'times': times_2d})
+        da = sig.fetch_as_xarray(0)
+        self.assertEqual(da.shape, (2, 4))
+        self.assertNotIn('times', da.coords)
+
+    def test_plain_1d_signal_unchanged(self):
+        """(N,) data + (N,) times keeps existing behavior (regression guard)."""
+        times = np.arange(6, dtype=float)
+        sig = self._signal_with_gather({'data': times * 3.0, 'times': times})
+        da = sig.fetch_as_xarray(0)
+        self.assertEqual(da.dims, ('times',))
+        np.testing.assert_array_equal(da['times'].values, times)

--- a/toksearch_d3d/signal/imas.py
+++ b/toksearch_d3d/signal/imas.py
@@ -500,6 +500,12 @@ class ImasSignal(Signal):
             if dim_name not in result:
                 continue
             dim_arr = np.asarray(result[dim_name])
+            if dim_arr.ndim == 2 and np.array_equal(
+                dim_arr, np.broadcast_to(dim_arr[0], dim_arr.shape)
+            ):
+                # Channel-indexed dim (e.g. magnetics.ip times of shape
+                # (n_chan, N)) whose rows are all identical: one shared axis.
+                dim_arr = dim_arr[0]
             if dim_arr.ndim != 1:
                 continue
             for ax in range(data.ndim):
@@ -508,6 +514,20 @@ class ImasSignal(Signal):
                     axis_coords[dim_name] = dim_arr
                     used_axes.add(ax)
                     break
+
+        # Singleton axes with no dim array (e.g. the 1-element measurement
+        # axis of magnetics.ip.data) would block alignment along 'times';
+        # drop them so single-channel signals behave like plain 1-D signals.
+        squeeze_axes = tuple(
+            ax for ax in range(data.ndim)
+            if ax not in axis_dims and data.shape[ax] == 1
+        )
+        if squeeze_axes:
+            data = np.squeeze(data, axis=squeeze_axes)
+            axis_dims = {
+                ax - sum(1 for s in squeeze_axes if s < ax): name
+                for ax, name in axis_dims.items()
+            }
 
         xr_dims = [axis_dims.get(ax, f'dim_{ax}') for ax in range(data.ndim)]
 


### PR DESCRIPTION
## Problem

Channel-indexed IDS leaves (e.g. `magnetics.ip.data`) gather as data `(n_chan, N)` with times also `(n_chan, N)`. `fetch_as_xarray` only matched **1-D** dim arrays to data axes, so the 2-D times array was skipped entirely: both axes received generic `dim_N` labels and no times coordinate was attached. That silently broke `fetch_dataset`/`align` for these signals:

```python
p.fetch_dataset('ds', {'ip': ImasSignal('magnetics.ip.data')})
# rec['ds']:  ip (dim_0, dim_1) ... no 'times' coordinate -> align() cannot work
```

## Fix

Two targeted changes in `fetch_as_xarray`, leaving `gather()`'s documented `(n_chan, N)` contract untouched:

1. A 2-D dim array whose rows are all identical (covers `n_chan == 1`, and multi-channel signals on a shared clock) collapses to its shared row before axis matching, so the time axis gets a real `times` coordinate.
2. Singleton axes with no dim array (the 1-element measurement axis of `magnetics.ip.data`) are squeezed, so single-channel signals behave like plain 1-D signals downstream.

Genuinely ragged per-channel timebases keep the previous behavior (generic labels, no shared coordinate), consistent with the existing docstring guidance to use `split_by='channel'` for those.

## Tests

- New unit tests with a stub composer (no network): `(1, N)` squeeze + times coord, identical `(3, N)` keeps channel axis + gains times coord, ragged unchanged, plain 1-D regression guard. Written first and watched fail (`('dim_0', 'dim_1') != ('times',)`).
- New live integration test: `magnetics.ip.data` end-to-end via the composer.
- Full `test_imas_signal.py` suite under `fdp run`: **50 tests OK**.

End-to-end acceptance (previously broken, now working):

```
<xarray.Dataset>  Dimensions: (shot: 1, times: 961)
Coordinates: * times  ...
Data variables: ip (times) float32 ...,  q95 (times) float32 ...
```

With this fix plus imas_composer >= 0.2.2 (conda-forge feedstock bump in conda-forge/imas_composer-feedstock#7), the disruption-tutorial feature set (`ip`, line-integrated density, `q95`, `li`, `betan`) can run entirely through `ImasSignal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)