### PR TITLE
PtDataSignal: take the ical mapping from ptdata, not a local copy

### DIFF
--- a/docs/ptdata.md
+++ b/docs/ptdata.md
@@ -72,13 +72,28 @@ for rec in records:
 
 ## Calibration (`ical`)
 
-By default data are returned calibrated (`ical=1`).  Pass `ical=0` to retrieve raw
-counts:
+By default data are returned in physics units (`ical=1`).  Pass `ical=0` to
+retrieve raw digitizer counts:
 
 ```python
 raw_sig = PtDataSignal('ip', ical=0)
 result  = raw_sig.fetch(202161)
 ```
+
+The full set of legacy PTDATA calibration flags:
+
+| `ical` | Data returned                        |
+| ------ | ------------------------------------ |
+| `0`    | Raw digitizer counts                 |
+| `1`    | Physics units (default)              |
+| `2`    | Volts into the digitizer             |
+| `4`    | Integrated signal (v-sec)            |
+
+Any other value raises `ptdata.PtDataError` (code 110,
+`InvalidConfiguration`) when the signal is constructed.  The flag is
+translated by `ptdata.calibration_mode_for_ical`, which refuses to guess:
+returning differently-calibrated data than you asked for is a units error
+that looks like valid data.
 
 ---
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -353,7 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py312ha7b3241_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.13-py312h738df08_0.conda
+      - conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.1.0-py312h738df08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
@@ -5891,21 +5891,21 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 225545
   timestamp: 1769678155334
-- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.0.13-py312h738df08_0.conda
-  sha256: 845f670bc3f2b95816766b1da968ea7303f512ab85631787bdd287deec7b3215
-  md5: fec05edd2afa612d4b581263b016acd7
+- conda: https://conda.anaconda.org/ga-fdp/linux-64/ptdata-2.1.0-py312h738df08_0.conda
+  sha256: d59d0b8a0a481aee58ece735928dbc4b5404a840ab0aa8551f24367c5c90ac93
+  md5: 0aa8bd5b0dd8eb7072e4dec43ae1505b
   depends:
   - python
   - numpy >=1.20,<2
   - libfdpio2 >=2.1.1,<3
   - libgfortran
   - __glibc >=2.17,<3.0.a0
-  - numpy >=1.26.4,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.26.4,<2.0a0
   - libfdpio2 >=2.0.0,<3.0.0a0
   license: Apache-2.0
-  size: 2899098
-  timestamp: 1784566361744
+  size: 2912393
+  timestamp: 1786720518569
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -7315,7 +7315,7 @@ packages:
   timestamp: 1780358168616
 - pypi: ./
   name: toksearch-d3d
-  version: 0.10.1+3.g0c71195.dirty
+  version: 0.10.1+27.g7db3d11.dirty
   sha256: e4d729b20ca23137c18fde910a61b4e02fefb6120f6c3f0ddd8af32b723b8dc2
   requires_dist:
   - imas-composer ; extra == 'imas'

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ platforms = ["linux-64"]
 [dependencies]
 python = ">=3.11"
 toksearch = ">=2.8.0"
-ptdata = ">=2.0.13,<3"
+ptdata = ">=2.1.0,<3"
 matplotlib = "*"
 imas_composer = ">=0.2.4,<0.3"
 filelock = ">=3"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - toksearch >=2.8.1
-    - ptdata >=2.0.13,<3
+    - ptdata >=2.1.0,<3
     - imas_composer >=0.2.4,<0.3
     - filelock >=3
     # CakeSignal fetches the CAKE DB by shelling out to the `pelican` CLI

--- a/tests/test_ptdata_signal_calibration.py
+++ b/tests/test_ptdata_signal_calibration.py
@@ -1,0 +1,138 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PtDataSignal's `ical` flag must reach the engine's CalibrationMode through
+ptdata's public `calibration_mode_for_ical` -- no local copy of the mapping.
+
+The copy this replaced was missing `2: Volts` and fell back to Full for
+anything it did not know, so `PtDataSignal(pt, ical=2)` silently returned
+Full-calibrated data: a units error that looks like valid data.
+
+These tests assert the *selected* CalibrationMode with a stub reader rather
+than fetching real data, so they run offline (no shot files, no ptserver) and
+check exactly the thing that used to be wrong.
+"""
+
+import unittest
+
+import ptdata
+from ptdata import _core
+
+from toksearch_d3d.signal.ptdata import (
+    PtDataSignal,
+    PtDataReaderRegistry,
+    RDataSignal,
+)
+
+
+class _StubResult:
+    """Minimal stand-in for ptdata.ExtractedData as gather() consumes it."""
+
+    data = [1.0, 2.0, 3.0]
+    raw_integer = []
+    times = [0.0, 1.0, 2.0]
+    units = "AMPS"
+    n_over = 0
+    n_under = 0
+
+
+class _RecordingReader:
+    """Captures the ExtractionParams each fetch was issued with."""
+
+    def __init__(self):
+        self.calibrations = []
+
+    def fetch(self, pointname, shot, params):
+        self.calibrations.append(params.calibration)
+        return _StubResult()
+
+
+class TestPtDataSignalCalibrationMode(unittest.TestCase):
+    SHOT = 165920
+    PTNAME = "ip"
+
+    def setUp(self):
+        self.reader = _RecordingReader()
+        # Seed the process-global registry so gather() picks up the stub
+        # instead of building a real PtDataReader.
+        registry = PtDataReaderRegistry()
+        registry._reader = self.reader
+
+    def tearDown(self):
+        PtDataReaderRegistry().close()
+
+    def _calibration_for(self, **kwargs):
+        PtDataSignal(self.PTNAME, **kwargs).fetch(self.SHOT)
+        self.assertEqual(len(self.reader.calibrations), 1)
+        return self.reader.calibrations[0]
+
+    def test_ical_2_selects_volts(self):
+        # The regression: this used to silently come back as Full.
+        self.assertEqual(self._calibration_for(ical=2),
+                         _core.CalibrationMode.Volts)
+
+    def test_default_ical_selects_full(self):
+        self.assertEqual(self._calibration_for(), _core.CalibrationMode.Full)
+
+    def test_ical_0_selects_raw(self):
+        self.assertEqual(self._calibration_for(ical=0),
+                         _core.CalibrationMode.Raw)
+
+    def test_ical_4_selects_linear(self):
+        self.assertEqual(self._calibration_for(ical=4),
+                         _core.CalibrationMode.Linear)
+
+    def test_signal_uses_ptdata_accessor(self):
+        """Not a private copy of the mapping."""
+        from toksearch_d3d.signal import ptdata as signal_ptdata
+        self.assertFalse(hasattr(signal_ptdata, "_ICAL_MAP"))
+        self.assertIs(signal_ptdata.calibration_mode_for_ical,
+                      ptdata.calibration_mode_for_ical)
+
+    def test_rdata_signal_still_fetches_full(self):
+        """RDataSignal hardcodes ical=1; it must keep working."""
+        RDataSignal().fetch(self.SHOT)
+        self.assertEqual(self.reader.calibrations,
+                         [_core.CalibrationMode.Full])
+
+
+class TestPtDataSignalUnsupportedIcal(unittest.TestCase):
+    """Behaviour change: an unsupported ical used to yield Full-calibrated
+    data; it now raises."""
+
+    SHOT = 165920
+    PTNAME = "ip"
+
+    def tearDown(self):
+        PtDataReaderRegistry().close()
+
+    def test_unsupported_ical_raises_at_construction(self):
+        for ical in (3, 5, 10, 20, -1):
+            with self.subTest(ical=ical):
+                with self.assertRaises(ptdata.PtDataError) as ctx:
+                    PtDataSignal(self.PTNAME, ical=ical)
+                # 110 = InvalidConfiguration (not 14, InvalidCallType: a bad
+                # ical is a bad argument, not a legacy call-type mismatch).
+                self.assertEqual(ctx.exception.code, 110)
+
+    def test_unsupported_ical_never_reaches_the_reader(self):
+        reader = _RecordingReader()
+        PtDataReaderRegistry()._reader = reader
+        with self.assertRaises(ptdata.PtDataError):
+            PtDataSignal(self.PTNAME, ical=3).fetch(self.SHOT)
+        self.assertEqual(reader.calibrations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toksearch_d3d/signal/ptdata.py
+++ b/toksearch_d3d/signal/ptdata.py
@@ -21,15 +21,11 @@ from toksearch import Signal
 from toksearch.utilities.utilities import set_env
 
 import ptdata
-from ptdata import _core
-
-
-# Legacy `ical` flag -> engine CalibrationMode. Mirrors ptdata.fetch._ICAL_MAP.
-_ICAL_MAP = {
-    0: _core.CalibrationMode.Raw,
-    1: _core.CalibrationMode.Full,
-    4: _core.CalibrationMode.Linear,
-}
+# calibration_mode_for_ical is ptdata's single source of truth for the legacy
+# `ical` flag -> CalibrationMode translation. It needs a newer ptdata than the
+# >=2.0.13 floor pinned in pixi.toml / recipe/recipe.yaml -- unreleased as of
+# this commit; bump both floors to the release that ships it.
+from ptdata import _core, calibration_mode_for_ical
 
 
 class PtDataReaderRegistry:
@@ -97,8 +93,15 @@ class PtDataSignal(Signal):
             routing (Pelican index vs local files vs ptserver/athena) is
             determined by the environment (`PTDATA_JSON_INDEX_DIR`, `SYS_D3`,
             `PTDATA_PTSERVERS`) set up by `fdp`, not by this flag.
-        ical: Calibration flag.  `1` (default) returns calibrated data;
-            `0` returns raw counts; `4` applies linear calibration.
+        ical: Legacy PTDATA calibration flag, translated by
+            `ptdata.calibration_mode_for_ical`. `1` (default) returns data in
+            physics units; `0` returns raw digitizer counts; `2` returns volts
+            into the digitizer; `4` returns the integrated signal (v-sec).
+            Any other value raises `ptdata.PtDataError` (code 110,
+            `InvalidConfiguration`) at construction rather than quietly
+            substituting a calibration -- returning differently-calibrated
+            data than the caller asked for is a units error that looks like
+            valid data.
         keep_header: If True, include the raw PTDATA header (a
             `ptdata.PtDataHeader`) in the result under the `'header'` key.
             Note: this incurs an extra header read.
@@ -114,6 +117,11 @@ class PtDataSignal(Signal):
         super().__init__()
         self.pointname = pointname
         self.remote = remote
+        # Reject an unsupported ical here, in the caller's own traceback,
+        # rather than once per shot inside a pipeline worker. The resolved
+        # mode is deliberately not cached on the instance: `ical` is a plain
+        # attribute a caller can reassign, so gather() re-resolves it.
+        calibration_mode_for_ical(ical)
         self.ical = ical
         self.keep_header = keep_header
         self.fetch_times = fetch_times
@@ -138,7 +146,7 @@ class PtDataSignal(Signal):
 
             params = _core.ExtractionParams()
             params.fetch_times = fetch_times
-            params.calibration = _ICAL_MAP.get(self.ical, _core.CalibrationMode.Full)
+            params.calibration = calibration_mode_for_ical(self.ical)
 
             result = reader.fetch(self.pointname, int(shot), params)
 


### PR DESCRIPTION
## The bug

`PtDataSignal(pointname, ical=2)` silently returned **Full-calibrated data**
instead of volts.

`ical` selects the physical units returned by PTData (`0` = raw digitizer
counts, `1` = physics units, `2` = volts into the digitizer, `4` = integrated
v-sec). This package kept its own copy of the translation table — the comment
on it says *"Mirrors ptdata.fetch._ICAL_MAP"* — and the mirror had drifted:

```python
_ICAL_MAP = {0: Raw, 1: Full, 4: Linear}          # no 2
...
_ICAL_MAP.get(self.ical, _core.CalibrationMode.Full)   # silent fallback
```

Any unsupported `ical` — 2, 3, 10–19, 20 — quietly became `Full`. A units error
that looks like a valid answer: right shape, right time base, wrong scale, no
error.

Demonstrated on real data, shot 165920:

```
PtDataSignal('ip', ical=2).fetch(165920)
  before:  -1391.2…    (amps — silently Full)
  after:   -0.00278…   (volts)
```

`ical=1` and `ical=2` previously returned *identical* arrays.

## The fix

Import the mapping from `ptdata` rather than mirroring it.
`ptdata.calibration_mode_for_ical()` (new in 2.1.0) is now the single source of
truth, so this cannot drift again — the alternative, syncing the copy, would
have put the same table in a third place.

The flag is validated in `__init__` rather than `gather`, so a bad `ical` fails
in the caller's traceback instead of once per shot inside a worker.

`RDataSignal` (which hardcodes `ical = 1`) is unaffected and covered by a test.

## ⚠️ Behaviour change

An `ical` outside `{0, 1, 2, 4}` now raises `PtDataError` with
`.code == 110` (`InvalidConfiguration`). It previously returned data. Since
that data was silently mis-calibrated, this converts a wrong answer into an
error — but pipelines passing an unsupported value will now fail where they
used to "work".

## Requires ptdata >= 2.1.0

Bumped in both `pixi.toml` and `recipe/recipe.yaml`. This is a hard floor, not
a preference: 2.0.13 has neither `calibration_mode_for_ical` nor
`CalibrationMode.Volts`, and importing against it fails outright — which, since
`fdp` loads this package's catalog entry point, would take the **`fdp` CLI**
down too. `ptdata 2.1.0` is on the `ga-fdp` channel (verified in
`repodata.json`).

`tests/test_fdp_decoupling.py` failed on exactly this gap before the floor moved
— it builds a scrubbed environment whose subprocess picked up the older ptdata —
and passes 6/6 now.

## Tests

New `tests/test_ptdata_signal_calibration.py` (8 cases): each supported `ical`
selects the right `CalibrationMode`, unsupported values raise, and `RDataSignal`
still works. They use a stub reader seeded into `PtDataReaderRegistry`, so no
shot files or ptserver are needed.

Full suite under the FDP environment: **112 passed, 6 skipped**.

Note these tests must run as `fdp run python -m pytest tests` — raw `pytest`
has no MDSplus tree paths and fails 40 IMAS tests with `TreeFOPENR`, which is
environmental and not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)