### PR TITLE
docs: make layout= discoverable from the agent-facing surface

### DIFF
--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -106,7 +106,35 @@ Use ``split_by='channel'`` for a dict keyed by channel name::
 
     ImasSignal('thomson_scattering.channel.n_e.data', split_by='channel')
 
-**NBI power recipe** (object array of 8 per-unit time series)::
+**Controlling shape with** ``layout=``: imas_composer 0.2.4 puts every
+``core_profiles.profiles_1d`` quantity on one shared time axis, leaving an
+*empty* slot where that quantity has no data.  ``layout=`` chooses how that
+is presented:
+
+- ``'compact'`` — drop the empty slots, filtering ``times`` in lockstep.
+  Rectangular when one common inner length remains.  **Default for leaf
+  paths.**
+- ``'filled'`` — keep every slot, NaN-padding the gaps so all leaves stay
+  index-aligned to one time axis.  **Default for prefix paths.**
+- ``'ragged'`` — no transformation; the object array as composed.
+- ``'awkward'`` — the raw ``ak.Array``.
+
+::
+
+    # rectangular (n_time, n_rho), the default
+    ImasSignal('core_profiles.profiles_1d.electrons.density')
+
+    # every slot kept, gaps NaN
+    ImasSignal('core_profiles.profiles_1d.electrons.density', layout='filled')
+
+Layout applies **only** when the outer axis is provably a time axis, so
+channel- and measurement-indexed data (ECE channels, ``magnetics.ip``) is
+never reshaped — entries there are matched positionally against sibling
+name arrays.  ``as_awkward`` is deprecated in favour of ``layout='awkward'``.
+
+**NBI power recipe** — 8 per-unit time series.  Object array under
+imas_composer 0.2; rectangular ``(8, n_time)`` under 0.2.4.  ``np.stack``
+handles both::
 
     import numpy as np
     nbi_data = rec.get('nbi', None)

--- a/toksearch_d3d/skills/toksearch-d3d-imas/SKILL.md
+++ b/toksearch_d3d/skills/toksearch-d3d-imas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: toksearch-d3d-imas
-description: ImasSignal for DIII-D IMAS IDS data — leaf/prefix paths, ragged arrays, channel splitting, dimension control, and shared ImasComposer
+description: ImasSignal for DIII-D IMAS IDS data — leaf/prefix paths, layout= control over ragged/jagged arrays (compact/filled/ragged/awkward), channel splitting, dimension control, and shared ImasComposer
 user-invocable: false
 license: Apache-2.0
 compatibility: Claude Code
@@ -18,4 +18,8 @@ Access it with: `help(toksearch_d3d)` or `python -c "help(toksearch_d3d)"`
 
 For detailed constructor parameters: `help(toksearch_d3d.ImasSignal)`
 
-Covers: leaf vs prefix paths, ragged arrays, split_by='channel', dims, dim_scales, NBI power recipe, ImasComposer sharing, list_imas_fields(), and common IDS paths.
+Covers: leaf vs prefix paths, `layout=` shape control (`compact`/`filled`/`ragged`/`awkward`, defaulting to `compact` for leaf paths and `filled` for prefix paths), ragged arrays, split_by='channel', dims, dim_scales, NBI power recipe, ImasComposer sharing, list_imas_fields(), and common IDS paths.
+
+Note: `core_profiles.profiles_1d` quantities are jagged under imas_composer
+0.2.4 (one shared time axis, empty slots where a quantity has no data).
+`layout=` is how you get a rectangular array back — see `help(toksearch_d3d)`.

--- a/toksearch_d3d/skills/toksearch-signal-routing/SKILL.md
+++ b/toksearch_d3d/skills/toksearch-signal-routing/SKILL.md
@@ -16,8 +16,8 @@ fails with `PtDataError: Shot.extension not found`. Use this table.
 | Stored energy Wmhd | `MdsSignal(r'\wmhd', 'efit01')` | **not** a PTDATA pointname; Joules -> /1e6 for MJ |
 | Normalized beta (beta_N) | `ImasSignal('equilibrium.time_slice.global_quantities.beta_normal')` | EFIT01-backed |
 | q95 | `ImasSignal('equilibrium.time_slice.global_quantities.q_95')` | |
-| Total NBI power | `ImasSignal('nbi.unit.power_launched.data')` | object array of per-unit W series (see recipe) |
-| Core electron density | `ImasSignal('core_profiles.profiles_1d.electrons.density')` | 2-D (time, rho) |
+| Total NBI power | `ImasSignal('nbi.unit.power_launched.data')` | 8 per-unit W series; `np.stack` then sum (see recipe) |
+| Core electron density | `ImasSignal('core_profiles.profiles_1d.electrons.density')` | 2-D (time, rho); jagged under imas_composer 0.2.4, made rectangular by the default `layout='compact'` |
 | Thomson Te (per channel) | `ImasSignal('thomson_scattering.channel.t_e.data', split_by='channel')` | dict keyed by channel |
 | Plasma boundary outline | `ImasSignal('equilibrium.time_slice.boundary.outline.r')` | ragged object array |
 


### PR DESCRIPTION
`release-0.11.0` documented `layout=` in `docs/imas.md` and the `ImasSignal`
docstring, but not on the path agents actually read.

`toksearch_d3d/__init__.py`'s package docstring had **zero** mentions of it —
and that is what `help(toksearch_d3d)` prints, what the `toksearch-d3d-imas`
skill calls "the canonical ImasSignal documentation", and what the root
`CLAUDE.md` instructs you to run before writing any pipeline script. The
skill's own `description:` advertised "ragged arrays" with no hint that shape
is now controllable, so an agent scanning skill descriptions could not
discover the feature at all.

That is backwards for a feature whose primary audience is agents, in a
package that ships an MCP skills server for them.

## Changes

- **package docstring** — document the four layout modes, the leaf/prefix
  defaults, and the axis rule that keeps channel- and measurement-indexed
  data from being reshaped
- **`toksearch-d3d-imas` skill** — name `layout=` in the `description:` and
  the Covers line, and note that `core_profiles` is jagged under
  `imas_composer` 0.2.4
- **`toksearch-signal-routing`** — correct the NBI row, which claimed an
  object array (it is rectangular `(8, n_time)` under 0.2.4), and note that
  core electron density is jagged-made-rectangular by the `compact` default

Docs only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)