### PR TITLE
docs: make help(toksearch_d3d) actually canonical

### DIFF
--- a/docs/imas.md
+++ b/docs/imas.md
@@ -129,6 +129,23 @@ object
 
 ---
 
+## Discovering which fields are available
+
+`list_imas_fields()` returns the IDS paths `imas_composer` can compose, so you
+can check a path before building a pipeline around it:
+
+```python
+from toksearch_d3d import list_imas_fields
+
+fields = list_imas_fields()          # every IDS
+fields = list_imas_fields('ece')     # one IDS
+```
+
+Pass an existing `ImasComposer` as `composer=` to reuse it rather than
+constructing a new one.
+
+---
+
 ## Fetching all fields under a prefix
 
 Instead of a full leaf path, you can pass a **dotted prefix** such as an IDS

--- a/toksearch_d3d/__init__.py
+++ b/toksearch_d3d/__init__.py
@@ -97,9 +97,13 @@ device packages, e.g. ``toksearch_mast.MastImasSignal``.
 
     ImasSignal('equilibrium.time_slice.global_quantities.ip')
 
-**Prefix path** — fetches all fields under a subtree::
+**Prefix path** — fetches all fields under a subtree, returning a dict keyed
+by full leaf path::
 
     ImasSignal('equilibrium.time_slice.global_quantities')
+
+*Prefix restrictions*: ``dims``, ``split_by`` and ``fetch_as_xarray()`` are
+not supported for prefix paths — prefix mode returns plain arrays only.
 
 **Ragged arrays**: channel-indexed data returns a numpy object array.
 Use ``split_by='channel'`` for a dict keyed by channel name::
@@ -141,6 +145,50 @@ handles both::
     if nbi_data is not None and nbi_data.get('data') is not None:
         units = np.stack(list(nbi_data['data']), axis=0).astype(float)
         total_mw = np.nanmax(np.nansum(units, axis=0)) / 1e6
+
+**Supplementary dimension arrays with** ``dims``: each key becomes a field in
+the result dict; each value is ``'auto'`` or an explicit IMAS path.  The
+default is ``dims={'times': 'auto'}``.
+
+``'auto'`` resolution: if ``ids_path`` ends in ``.data`` or
+``.data_error_upper``, the suffix is stripped, the dim name appended, and the
+path traversed upward toward the IDS root until one resolves — for
+``ece.channel.t_e.data`` with ``dim='times'`` the candidates are
+``ece.channel.t_e.time`` → ``ece.channel.time`` → ``ece.time``.  Otherwise
+the fallback is ``{ids_name}.{dim_name}``::
+
+    # add a second dimension
+    ImasSignal('thomson_scattering.channel.position.r',
+               dims={'times': 'auto',
+                     'z': 'thomson_scattering.channel.position.z'})
+    # -> keys: 'data', 'times', 'z'
+
+    # suppress times entirely
+    ImasSignal('equilibrium.time_slice.global_quantities.ip', dims={})
+    # -> keys: 'data'
+
+**Time units with** ``dim_scales``: dimensions are scaled by these factors.
+The default ``{'times': 1000.0}`` converts IMAS seconds to milliseconds,
+matching the PTData/toksearch convention.  Pass ``{'times': 1.0}`` for raw
+IMAS seconds.  Applies to any dimension, not just ``'times'``.
+
+**Converting to xarray** with ``fetch_as_xarray()``: scalar and profile
+signals return an ``xr.DataArray`` (dimension names come from resolved
+``dims``; unmatched axes get ``'dim_N'``); ``split_by='channel'`` returns an
+``xr.Dataset`` with one variable per channel.  It raises
+``NotImplementedError`` for prefix paths and for ragged object arrays — for
+the latter, ``layout='compact'`` or ``'filled'`` often yields a rectangular
+array it accepts.  Channels on heterogeneous time bases are merged with an
+outer join, so a channel is NaN where it has no measurement; use
+``Pipeline.align()`` for a uniform grid.
+
+**Specifying a data location** with ``location=``: accepts the same formats
+as ``MdsSignal`` — a filesystem path for local trees, or
+``'remote://server'``.  Under the FDP/Pelican stack ``fdp run`` sets the
+environment up, so the default ``None`` is correct::
+
+    ImasSignal('equilibrium.time_slice.global_quantities.ip',
+               location='remote://atlas.gat.com')
 
 **Sharing a composer** avoids repeated mapper init::
 


### PR DESCRIPTION
The shipped `toksearch-d3d-imas` skill tells agents *"the canonical ImasSignal
documentation lives in the `toksearch_d3d` package docstring."* It didn't.

That skill used to be a 356-line standalone document. When it was converted to
a 25-line pointer stub, its content moved to `docs/imas.md` — but **five of its
eleven topics never reached the docstring the stub points at**:

| topic | `help(toksearch_d3d)` before | `docs/imas.md` |
|---|---|---|
| `dims=` | ❌ | ✅ |
| `dim_scales` / time units | ❌ | ✅ |
| `fetch_as_xarray` | ❌ | ✅ |
| `location=` | ❌ | ✅ |
| prefix-mode restrictions | ❌ | ✅ |
| `list_imas_fields` | ✅ | ❌ |

**`docs/imas.md` does not ship.** `pyproject.toml` `package-data` installs
`skills/*/SKILL.md`; `docs/` sits outside every declared package. So an agent
with an installed `toksearch_d3d` and no web access was directed to a docstring
that could not teach it half the API — `dims`, `dim_scales`, `fetch_as_xarray`,
`location=`, or why prefix mode rejects all three.

## Changes

- Port those five topics into the package docstring, including the `'auto'`
  dim-resolution traversal order and the `fetch_as_xarray` limitations.
- Close the reverse gap: document `list_imas_fields()` in `docs/imas.md`, which
  had it only in the docstring. Neither location was complete.

Docs only — no behaviour change. 81 IMAS tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)